### PR TITLE
Support new sub_label format from Frigate

### DIFF
--- a/Frigate Camera Notifications/Beta
+++ b/Frigate Camera Notifications/Beta
@@ -1,5 +1,5 @@
 blueprint:
-  name: Frigate Notifications (0.12.0.1t)
+  name: Frigate Notifications (0.12.0.3)
   description: |
     ## Frigate Notifications
 

--- a/Frigate Camera Notifications/Beta
+++ b/Frigate Camera Notifications/Beta
@@ -1113,8 +1113,19 @@ action:
                     zone_only_changed: "{{ zone_only and (enteredzones|length > 0 and not last_zones|length) }}"
                     entered_zones_changed: "{{ zones|length > 0 and (zones|select('in', enteredzones)|list|length > 0 and not zones|select('in', last_zones)|list|length) }}"
                     state_true: "{{ not state_only or states(input_entity) in states_filter }}"
-                    sub_label: "{{ event['after']['sub_label']}}"
-                    sub_label_changed: "{{ sub_label != event['before']['sub_label'] }}"
+                    sub_label: >
+                      {% if event['after']['sub_label'] %} 
+                        {{event['after']['sub_label'][0]}}
+                      {%else%}
+                        {{event['after']['sub_label']}}
+                      {%endif%}
+                    sub_label_before: >
+                      {% if event['before']['sub_label'] %} 
+                        {{event['before']['sub_label'][0]}}
+                      {%else%}
+                        {{event['before']['sub_label']}}
+                      {%endif%}
+                    sub_label_changed: "{{ sub_label != sub_label_before }}"
                     update: "{{ alert_once or (new_snapshot and not loitering and not presence_changed and not zone_only_changed and not entered_zones_changed and not sub_label_changed) }}"
                     critical_input: !input critical
                     critical: "{{ true if critical_input == 'true' else true if critical_input == True else false }}"


### PR DESCRIPTION
In 0.13.0-beta the structure of the sub_label changed to include a person name AND score.

Could be improved to better test for null values, or support both versions of the field at the same time.

Tested against Frigate 0.13.0-beta5 and DoubleTake 1.13.11.8 (fork https://github.com/skrashevich/double-take/)