### PR TITLE
Update default icon

### DIFF
--- a/Frigate Camera Notifications/Beta
+++ b/Frigate Camera Notifications/Beta
@@ -274,11 +274,11 @@ blueprint:
     icon:
       name: Notification Icon (Optional)
       description: Change the icon that displays on the notification. You can enter a single icon or create a template like the example given in the dropdown. You must include 'mdi:' in the icon name.
-      default: mdi:frigate
+      default: mdi:homeassistant
       selector:
         select:
           options:
-            - mdi:frigate
+            - mdi:homeassistant
             - mdi:cctv
             - "mdi:{{'account-outline' if label == 'Person' else 'dog' if label == 'Dog' else 'cat' if label == 'Cat' else 'car' if label == 'Car' else 'home-assistant'}}"
           custom_value: true

--- a/Frigate Camera Notifications/Beta
+++ b/Frigate Camera Notifications/Beta
@@ -274,11 +274,11 @@ blueprint:
     icon:
       name: Notification Icon (Optional)
       description: Change the icon that displays on the notification. You can enter a single icon or create a template like the example given in the dropdown. You must include 'mdi:' in the icon name.
-      default: mdi:home-assistant
+      default: mdi:frigate
       selector:
         select:
           options:
-            - mdi:home-assistant
+            - mdi:frigate
             - mdi:cctv
             - "mdi:{{'account-outline' if label == 'Person' else 'dog' if label == 'Dog' else 'cat' if label == 'Cat' else 'car' if label == 'Car' else 'home-assistant'}}"
           custom_value: true


### PR DESCRIPTION
The home-assistant icon has not been updated and is scheduled to be removed. Sending an invalid icon will cause the app to use the default icon. https://github.com/home-assistant/android/issues/4252

closes #148