### PR TITLE
Global Conditions

### DIFF
--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -1,5 +1,5 @@
 blueprint:
-  name: Frigate Notifications (0.12.0.4e)
+  name: Frigate Notifications (0.12.0.4f)
   author: SgtBatten
   homeassistant:
     min_version: 2024.6.0

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -363,6 +363,12 @@ blueprint:
       icon: mdi:filter
       collapsed: true
       input:
+        condition_global:
+          name: Add Condition(s) to run this Automation
+          description: Add conditions if needed to run this automation at all. If conditions return `false`, no actions will fire.
+          default: []
+          selector:
+            condition: {}
         zone_filter:
           name: Zone Filter on/off (Optional)
           description: Enable to only notify if an object has entered a zone listed below.
@@ -870,7 +876,11 @@ variables:
   tv_transparency: !input tv_transparency
   tv_interrupt: !input tv_interrupt
   debug: !input debug
+  condition_global: !input condition_global
 action:
+- if:
+  - condition: !input condition_global
+  then:
   - choose:
       - alias: "Silence New Object Notifications"
         conditions:

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -363,9 +363,9 @@ blueprint:
       icon: mdi:filter
       collapsed: true
       input:
-        condition_global:
-          name: Add Condition(s) to run this Automation
-          description: Add conditions if needed to run this automation at all. If conditions return `false`, no actions will fire.
+        master_condition:
+          name: Master Condition (Optional)
+          description: Set conditions that will stop the automation from running if the result is false. No other tests will be conducted later. This is a kill switch on initiation.
           default: []
           selector:
             condition: {}
@@ -876,10 +876,10 @@ variables:
   tv_transparency: !input tv_transparency
   tv_interrupt: !input tv_interrupt
   debug: !input debug
-  condition_global: !input condition_global
+  master_condition: !input master_condition
 action:
 - if:
-  - condition: !input condition_global
+  - condition: !input master_condition
   then:
   - choose:
       - alias: "Silence New Object Notifications"

--- a/Frigate_Camera_Notifications/Stable.yaml
+++ b/Frigate_Camera_Notifications/Stable.yaml
@@ -104,12 +104,6 @@ blueprint:
 
         Note: If the group contains both mobile devices and TVs, the TV will not display the snapshot unless "TV notifications" is set to true. However, this will stop Android phones from receiving thumbnails.
       default: ""
-    condition_global:
-      name: Add Condition(s) to run this Automation
-      description: Add conditions if needed to run this automation at all. If conditions return `false`, no actions will fire.
-      default: []
-      selector:
-        condition: {}
     base_url:
       name: Base URL (Optional)
       description: |
@@ -849,11 +843,7 @@ variables:
   tv_transparency: !input tv_transparency
   tv_interrupt: !input tv_interrupt
   debug: !input debug
-  condition_global: !input condition_global
 action:
-- if:
-  - condition: !input condition_global
-  then:
   - choose:
       - alias: "Silence New Object Notifications"
         conditions:

--- a/Frigate_Camera_Notifications/Stable.yaml
+++ b/Frigate_Camera_Notifications/Stable.yaml
@@ -106,7 +106,7 @@ blueprint:
       default: ""
     condition_global:
       name: Add Condition(s) to run this Automation
-      description: Add conditions if needed to run this automation at all. Note, if conditions return `false`, no actions will fire.
+      description: Add conditions if needed to run this automation at all. If conditions return `false`, no actions will fire.
       default: []
       selector:
         condition: {}

--- a/Frigate_Camera_Notifications/Stable.yaml
+++ b/Frigate_Camera_Notifications/Stable.yaml
@@ -1,5 +1,5 @@
 blueprint:
-  name: Frigate Notifications (0.12.0.4c)
+  name: Frigate Notifications (0.12.0.4d)
   author: SgtBatten
   homeassistant:
     min_version: 2024.6.0
@@ -104,6 +104,12 @@ blueprint:
 
         Note: If the group contains both mobile devices and TVs, the TV will not display the snapshot unless "TV notifications" is set to true. However, this will stop Android phones from receiving thumbnails.
       default: ""
+    condition_global:
+      name: Add Condition(s) to run this Automation
+      description: Add conditions if needed to run this automation at all. Note, if conditions return `false`, no actions will fire.
+      default: []
+      selector:
+        condition: {}
     base_url:
       name: Base URL (Optional)
       description: |
@@ -843,7 +849,11 @@ variables:
   tv_transparency: !input tv_transparency
   tv_interrupt: !input tv_interrupt
   debug: !input debug
+  condition_global: !input condition_global
 action:
+- if:
+  - condition: !input condition_global
+  then:
   - choose:
       - alias: "Silence New Object Notifications"
         conditions:


### PR DESCRIPTION
This is similar to your `State Filter` but sometimes the automation will still fire when `false` (I had it set to only fire when the home alarm was armed, but it would sometime fire regardless of that state). Also, I wanted to utilize more complex conditions in order to fire the automation, which the `State Filter` seems to really only allow one entity (other than the  `Presence Filter`). I think this would be a great addition for further customization without losing any functionality. 

![Screenshot 2024-08-29 224057](https://github.com/user-attachments/assets/6c6a577b-d9af-4400-84da-407940ae4659)