### PR TITLE
Restore or Add Custom Action Trigger in Beta.yaml

### DIFF
--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -831,6 +831,11 @@ trigger:
     event_data:
       action: "silence-{{ this.entity_id }}"
     id: silence
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: custom-{{ this.entity_id }}
+    id: custom
   - platform: mqtt
     topic: "{{mqtt_topic}}"
     payload: "new"


### PR DESCRIPTION
Hi,
I don't know if the absence of the Custom Action Manual trigger is intentional, but I added it in order to manually activate my siren from the notification.