### PR TITLE
Implement telegram integration

### DIFF
--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -115,13 +115,13 @@ blueprint:
       name: API URL (Optional)
       description: |
         The API URL for downloading files for telegram integration.
-        Required if Telegram Chat ID is set.
+        Required if Telegram Chat ID is set and bearer token is unset.
       default: ""
     bearer_token:
       name: Bearer token (Optional)
       description: |
         Bearer token is used instead of accessing API via unsecure ports.
-        Required if Telegram Chat ID is set.
+        Required if Telegram Chat ID is set and API URL is unset.
         Bearer token should be generated as HS256 JWT with Frigate JWT secret.
       default: ""
     base_url:

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -1097,7 +1097,21 @@ action:
                   - "{{ custom_filter }}"
                 sequence:
                   - choose:
-                      - conditions: "{{ not notify_group_target and not telegram }}"
+                      - conditions: "{{ telegram }}"
+                        sequence:
+                         - service: telegram_bot.send_photo
+                           data:
+                             target: "{{telegram_chat_id}}"
+                             caption: "{{message}}"
+                             password: "{{ bearer_token if bearer_token else '' }}"
+                             authentication: "{{ 'bearer_token' if bearer_token else '' }}"
+                             url: >
+                               {% if bearer_token %}
+                                {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}
+                               {% else %}
+                                {{api_url}}/api/events/{{id}}/{{attachment}}
+                               {% endif %}
+                      - conditions: "{{ not notify_group_target }}"
                         sequence:
                           - device_id: !input notify_device
                             domain: mobile_app
@@ -1201,20 +1215,6 @@ action:
                                     uri: "{{url_3}}"
                                     icon: "{{icon_3}}"
                                     destructive: true
-                      - conditions: "{{ telegram }}"
-                        sequence:
-                         - service: telegram_bot.send_photo
-                           data:
-                             target: "{{telegram_chat_id}}"
-                             caption: "{{message}}"
-                             password: "{{ bearer_token if bearer_token else '' }}"
-                             authentication: "{{ 'bearer_token' if bearer_token else '' }}"
-                             url: >
-                               {% if bearer_token %}
-                                {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}
-                               {% else %}
-                                {{api_url}}/api/events/{{id}}/{{attachment}}
-                               {% endif %}
                     default:
                       - service: "notify.{{ notify_group_target }}"
                         data:
@@ -1269,7 +1269,7 @@ action:
                                 icon: "{{icon_3}}"
                                 destructive: true
 
-                  - if: "{{tts and not telegram and (not tts_helper or not alert_once or (tts_helper and id not in states(tts_helper)))}}"
+                  - if: "{{tts and (not tts_helper or not alert_once or (tts_helper and id not in states(tts_helper)))}}"
                     then:
                       sequence:
                         - choose:
@@ -1458,7 +1458,45 @@ action:
                     - conditions: "{{ loitering or (custom_filter and not home and zones_satisfied and state_true and (new_snapshot or presence_changed or stationary_moved or entered_new_zones or entered_new_filter_zones or sub_label_changed)) }}"
                       sequence:
                         - choose:
-                            - conditions: "{{ not notify_group_target and not telegram }}"
+                            - conditions: "{{ telegram }}"
+                              sequence:
+                                - choose:
+                                  - conditions:
+                                    - "{{ event['type'] == 'end' }}"
+                                    - "{{ video | length > 0 }}"
+                                    sequence:
+                                      - service: telegram_bot.send_video
+                                        data:
+                                          target: "{{telegram_chat_id}}"
+                                          caption: "{{message}}"
+                                          password: "{{ bearer_token if bearer_token else '' }}"
+                                          authentication: "{{ 'bearer_token' if bearer_token else '' }}"
+                                          url: >
+                                            {% if bearer_token %}
+                                              {{ video }}
+                                            {% else %}
+                                              {{api_url}}/api/events/{{id}}/clip.mp4
+                                            {% endif %}
+                                          inline_keyboard:
+                                            - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
+                                            - [["{{button_3}}", "{{url_3}}"]]
+                                  default:
+                                    - service: telegram_bot.send_photo
+                                      data:
+                                        target: "{{telegram_chat_id}}"
+                                        caption: "{{message}}"
+                                        password: "{{ bearer_token if bearer_token else '' }}"
+                                        authentication: "{{ 'bearer_token' if bearer_token else '' }}"
+                                        url: >
+                                           {% if bearer_token %}
+                                            {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}
+                                           {% else %}
+                                            {{api_url}}/api/events/{{id}}/{{attachment}}
+                                           {% endif %}
+                                        inline_keyboard:
+                                          - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
+                                          - [["{{button_3}}", "{{url_3}}"]]
+                            - conditions: "{{ not notify_group_target }}"
                               sequence:
                                 - device_id: !input notify_device
                                   domain: mobile_app
@@ -1565,44 +1603,6 @@ action:
                                           uri: "{{url_3}}"
                                           icon: "{{icon_3}}"
                                           destructive: true
-                            - conditions: "{{ telegram }}"
-                              sequence:
-                                - choose:
-                                  - conditions:
-                                    - "{{ event['type'] == 'end' }}"
-                                    - "{{ video | length > 0 }}"
-                                    sequence:
-                                      - service: telegram_bot.send_video
-                                        data:
-                                          target: "{{telegram_chat_id}}"
-                                          caption: "{{message}}"
-                                          password: "{{ bearer_token if bearer_token else '' }}"
-                                          authentication: "{{ 'bearer_token' if bearer_token else '' }}"
-                                          url: >
-                                            {% if bearer_token %}
-                                              {{ video }}
-                                            {% else %}
-                                              {{api_url}}/api/events/{{id}}/clip.mp4
-                                            {% endif %}
-                                          inline_keyboard:
-                                            - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
-                                            - [["{{button_3}}", "{{url_3}}"]]
-                                  default:
-                                    - service: telegram_bot.send_photo
-                                      data:
-                                        target: "{{telegram_chat_id}}"
-                                        caption: "{{message}}"
-                                        password: "{{ bearer_token if bearer_token else '' }}"
-                                        authentication: "{{ 'bearer_token' if bearer_token else '' }}"
-                                        url: >
-                                           {% if bearer_token %}
-                                            {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}
-                                           {% else %}
-                                            {{api_url}}/api/events/{{id}}/{{attachment}}
-                                           {% endif %}
-                                        inline_keyboard:
-                                          - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
-                                          - [["{{button_3}}", "{{url_3}}"]]
                           default:
                             - service: "notify.{{ notify_group_target }}"
                               data:
@@ -1658,7 +1658,7 @@ action:
                                       icon: "{{icon_3}}"
                                       destructive: true
 
-                        - if: "{{tts and not telegram and (not tts_helper or not alert_once or (tts_helper and id not in states(tts_helper)))}}"
+                        - if: "{{tts and (not tts_helper or not alert_once or (tts_helper and id not in states(tts_helper)))}}"
                           then:
                             sequence:
                               - choose:

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -104,6 +104,18 @@ blueprint:
 
         Note: If the group contains both mobile devices and TVs, the TV will not display the snapshot unless "TV notifications" is set to true. However, this will stop Android phones from receiving thumbnails.
       default: ""
+    notify_telegram_chat_id:
+      name: Telegram Chat ID (Optional)
+      description: |
+        The chat ID to send telegram notifications to.
+        If set, this will override individual devices and groups above. Note: TV (far below) must be set to false.
+      default: ""
+    api_url:
+      name: API URL (Optional)
+      description: |
+        The API URL for downloading files for telegram integration.
+        Required if Telegram Chat ID is set.
+      default: ""
     base_url:
       name: Base URL (Optional)
       description: |
@@ -837,6 +849,8 @@ variables:
   camera_name: "{{ camera | replace('_', ' ') | title }}"
   input_base_url: !input base_url
   base_url: "{{ input_base_url.rstrip('/')}}"
+  input_api_url: !input api_url
+  api_url: "{{ input_api_url.rstrip('/')}}"
   update_sub_label: !input update_sub_label
   input_client_id: !input client_id
   client_id: "{{input_client_id if not input_client_id else '/' + input_client_id if '/' not in input_client_id else input_client_id }}"
@@ -847,6 +861,8 @@ variables:
   android_auto: !input android_auto
   notify_group: !input notify_group
   notify_group_target: "{{ notify_group | lower | regex_replace('^notify\\.', '') | replace(' ','_') }}"
+  telegram_chat_id: !input notify_telegram_chat_id
+  telegram: "{{true if ((telegram_chat_id | length > 0) and api_url) else ''}}"
   zone_only: !input zone_filter
   input_zones: !input zones
   zones: "{{ input_zones }}"
@@ -990,6 +1006,7 @@ action:
                             Input Camera(formatted): {{input_camera}}({{input_camera_name}}), 
                             Trigger Camera(formatted): {{camera}}({{camera_name}}), 
                             Base URL: {{'REDACTED' if base_url and redacted else base_url}}, 
+                            API URL: {{'REDACTED' if api_url and redacted else api_url}},
                             critical: {{critical}}, 
                             tts: {{tts}} 
                             helper: {{tts_helper if tts else 'N/A'}},
@@ -1021,6 +1038,8 @@ action:
                             tv_duration: {{tv_duration}}, 
                             tv_transparency: {{tv_transparency}}, 
                             tv_interrupt: {{tv_interrupt}}, 
+                            telegram: {{telegram}},
+                            telegram_chat_id: {{telegram_chat_id}},
                           Filters: 
                             Zones: 
                               Zone Filter toggle on: {{zone_only}}, 
@@ -1069,7 +1088,7 @@ action:
                   - "{{ custom_filter }}"
                 sequence:
                   - choose:
-                      - conditions: "{{ not notify_group_target }}"
+                      - conditions: "{{ not notify_group_target and not telegram }}"
                         sequence:
                           - device_id: !input notify_device
                             domain: mobile_app
@@ -1173,6 +1192,13 @@ action:
                                     uri: "{{url_3}}"
                                     icon: "{{icon_3}}"
                                     destructive: true
+                      - conditions: "{{ telegram }}"
+                        sequence:
+                         - service: telegram_bot.send_photo
+                           data:
+                             target: "{{telegram_chat_id}}"
+                             caption: "{{message}}"
+                             url: "{{api_url}}/api/events/{{id}}/{{attachment}}"
                     default:
                       - service: "notify.{{ notify_group_target }}"
                         data:
@@ -1227,7 +1253,7 @@ action:
                                 icon: "{{icon_3}}"
                                 destructive: true
 
-                  - if: "{{tts and (not tts_helper or not alert_once or (tts_helper and id not in states(tts_helper)))}}"
+                  - if: "{{tts and not telegram and (not tts_helper or not alert_once or (tts_helper and id not in states(tts_helper)))}}"
                     then:
                       sequence:
                         - choose:
@@ -1416,7 +1442,7 @@ action:
                     - conditions: "{{ loitering or (custom_filter and not home and zones_satisfied and state_true and (new_snapshot or presence_changed or stationary_moved or entered_new_zones or entered_new_filter_zones or sub_label_changed)) }}"
                       sequence:
                         - choose:
-                            - conditions: "{{ not notify_group_target }}"
+                            - conditions: "{{ not notify_group_target and not telegram }}"
                               sequence:
                                 - device_id: !input notify_device
                                   domain: mobile_app
@@ -1523,6 +1549,30 @@ action:
                                           uri: "{{url_3}}"
                                           icon: "{{icon_3}}"
                                           destructive: true
+                            - conditions: "{{ telegram }}"
+                              sequence:
+                                - choose:
+                                  - conditions:
+                                    - "{{ event['type'] == 'end' }}"
+                                    - "{{ video | length > 0 }}"
+                                    sequence:
+                                      - service: telegram_bot.send_video
+                                        data:
+                                          target: "{{telegram_chat_id}}"
+                                          caption: "{{message}}"
+                                          url: "{{api_url}}/api/events/{{id}}/clip.mp4"
+                                          inline_keyboard:
+                                            - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
+                                            - [["{{button_3}}", "{{url_3}}"]]
+                                  default:
+                                    - service: telegram_bot.send_photo
+                                      data:
+                                        target: "{{telegram_chat_id}}"
+                                        caption: "{{message}}"
+                                        url: "{{api_url}}/api/events/{{id}}/{{attachment}}"
+                                        inline_keyboard:
+                                          - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
+                                          - [["{{button_3}}", "{{url_3}}"]]
                           default:
                             - service: "notify.{{ notify_group_target }}"
                               data:
@@ -1578,7 +1628,7 @@ action:
                                       icon: "{{icon_3}}"
                                       destructive: true
 
-                        - if: "{{tts and (not tts_helper or not alert_once or (tts_helper and id not in states(tts_helper)))}}"
+                        - if: "{{tts and not telegram and (not tts_helper or not alert_once or (tts_helper and id not in states(tts_helper)))}}"
                           then:
                             sequence:
                               - choose:

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -112,9 +112,9 @@ blueprint:
         Base URL must start with https since telegram URL buttons only work with https.
       default: ""
     frigate_url:
-      name: Frigate API URL (Optional)
+      name: Frigate Base URL (Optional)
       description: |
-        The Frigate API URL for downloading files for telegram integration.
+        The Frigate Base URL for downloading files for telegram integration.
         Required if Telegram Chat ID is set and bearer token is unset.
       default: ""
     bearer_token:
@@ -1015,7 +1015,7 @@ action:
                             Input Camera(formatted): {{input_camera}}({{input_camera_name}}), 
                             Trigger Camera(formatted): {{camera}}({{camera_name}}), 
                             Base URL: {{'REDACTED' if base_url and redacted else base_url}}, 
-                            Frigate API URL: {{'REDACTED' if frigate_url and redacted else frigate_url}},
+                            Frigate Base URL: {{'REDACTED' if frigate_url and redacted else frigate_url}},
                             critical: {{critical}}, 
                             tts: {{tts}} 
                             helper: {{tts_helper if tts else 'N/A'}},

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -111,17 +111,17 @@ blueprint:
         If set, this will override individual devices and groups above. Note: TV (far below) must be set to false.
         Base URL must start with https since telegram URL buttons only work with https.
       default: ""
-    api_url:
-      name: API URL (Optional)
+    frigate_url:
+      name: Frigate API URL (Optional)
       description: |
-        The API URL for downloading files for telegram integration.
+        The Frigate API URL for downloading files for telegram integration.
         Required if Telegram Chat ID is set and bearer token is unset.
       default: ""
     bearer_token:
       name: Bearer token (Optional)
       description: |
-        Bearer token is used instead of accessing API via unsecure ports.
-        Required if Telegram Chat ID is set and API URL is unset.
+        Bearer token is used instead of accessing Frigate API via unsecure ports.
+        Required if Telegram Chat ID is set and Frigate API URL is unset.
         Bearer token should be generated as HS256 JWT with Frigate JWT secret.
       default: ""
     base_url:
@@ -857,8 +857,8 @@ variables:
   camera_name: "{{ camera | replace('_', ' ') | title }}"
   input_base_url: !input base_url
   base_url: "{{ input_base_url.rstrip('/')}}"
-  input_api_url: !input api_url
-  api_url: "{{ input_api_url.rstrip('/')}}"
+  input_frigate_url: !input frigate_url
+  frigate_url: "{{ input_frigate_url.rstrip('/')}}"
   update_sub_label: !input update_sub_label
   input_client_id: !input client_id
   client_id: "{{input_client_id if not input_client_id else '/' + input_client_id if '/' not in input_client_id else input_client_id }}"
@@ -871,7 +871,7 @@ variables:
   notify_group_target: "{{ notify_group | lower | regex_replace('^notify\\.', '') | replace(' ','_') }}"
   telegram_chat_id: !input notify_telegram_chat_id
   bearer_token: !input bearer_token
-  telegram: "{{true if ((telegram_chat_id | length > 0) and (api_url or bearer_token)) else ''}}"
+  telegram: "{{true if ((telegram_chat_id | length > 0) and (frigate_url or bearer_token)) else ''}}"
   zone_only: !input zone_filter
   input_zones: !input zones
   zones: "{{ input_zones }}"
@@ -1015,7 +1015,7 @@ action:
                             Input Camera(formatted): {{input_camera}}({{input_camera_name}}), 
                             Trigger Camera(formatted): {{camera}}({{camera_name}}), 
                             Base URL: {{'REDACTED' if base_url and redacted else base_url}}, 
-                            API URL: {{'REDACTED' if api_url and redacted else api_url}},
+                            Frigate API URL: {{'REDACTED' if frigate_url and redacted else frigate_url}},
                             critical: {{critical}}, 
                             tts: {{tts}} 
                             helper: {{tts_helper if tts else 'N/A'}},
@@ -1109,7 +1109,7 @@ action:
                                {% if bearer_token %}
                                 {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}
                                {% else %}
-                                {{api_url}}/api/events/{{id}}/{{attachment}}
+                                {{frigate_url}}/api/events/{{id}}/{{attachment}}
                                {% endif %}
                       - conditions: "{{ not notify_group_target }}"
                         sequence:
@@ -1475,7 +1475,7 @@ action:
                                             {% if bearer_token %}
                                               {{ video }}
                                             {% else %}
-                                              {{api_url}}/api/events/{{id}}/clip.mp4
+                                              {{frigate_url}}/api/events/{{id}}/clip.mp4
                                             {% endif %}
                                           inline_keyboard:
                                             - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
@@ -1491,7 +1491,7 @@ action:
                                            {% if bearer_token %}
                                             {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}
                                            {% else %}
-                                            {{api_url}}/api/events/{{id}}/{{attachment}}
+                                            {{frigate_url}}/api/events/{{id}}/{{attachment}}
                                            {% endif %}
                                         inline_keyboard:
                                           - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -1,5 +1,5 @@
 blueprint:
-  name: Frigate Notifications (0.12.0.5)
+  name: Frigate Notifications (0.12.0.5b)
   author: SgtBatten
   homeassistant:
     min_version: 2024.6.0

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -109,6 +109,7 @@ blueprint:
       description: |
         The chat ID to send telegram notifications to.
         If set, this will override individual devices and groups above. Note: TV (far below) must be set to false.
+        Base URL must start with https since telegram URL buttons only work with https.
       default: ""
     api_url:
       name: API URL (Optional)

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -111,19 +111,6 @@ blueprint:
         If set, this will override individual devices and groups above. Note: TV (far below) must be set to false.
         Base URL must start with https since telegram URL buttons only work with https.
       default: ""
-    frigate_url:
-      name: Frigate Base URL (Optional)
-      description: |
-        The Frigate Base URL for downloading files for telegram integration.
-        Required if Telegram Chat ID is set and bearer token is unset.
-      default: ""
-    bearer_token:
-      name: Bearer token (Optional)
-      description: |
-        Bearer token is used instead of accessing Frigate API via unsecure ports.
-        Required if Telegram Chat ID is set and Frigate API URL is unset.
-        Bearer token should be generated as HS256 JWT with Frigate JWT secret.
-      default: ""
     base_url:
       name: Base URL (Optional)
       description: |
@@ -857,8 +844,6 @@ variables:
   camera_name: "{{ camera | replace('_', ' ') | title }}"
   input_base_url: !input base_url
   base_url: "{{ input_base_url.rstrip('/')}}"
-  input_frigate_url: !input frigate_url
-  frigate_url: "{{ input_frigate_url.rstrip('/')}}"
   update_sub_label: !input update_sub_label
   input_client_id: !input client_id
   client_id: "{{input_client_id if not input_client_id else '/' + input_client_id if '/' not in input_client_id else input_client_id }}"
@@ -870,8 +855,7 @@ variables:
   notify_group: !input notify_group
   notify_group_target: "{{ notify_group | lower | regex_replace('^notify\\.', '') | replace(' ','_') }}"
   telegram_chat_id: !input notify_telegram_chat_id
-  bearer_token: !input bearer_token
-  telegram: "{{true if ((telegram_chat_id | length > 0) and (frigate_url or bearer_token)) else ''}}"
+  telegram: "{{true if (telegram_chat_id | length > 0) else ''}}"
   zone_only: !input zone_filter
   input_zones: !input zones
   zones: "{{ input_zones }}"
@@ -1015,7 +999,6 @@ action:
                             Input Camera(formatted): {{input_camera}}({{input_camera_name}}), 
                             Trigger Camera(formatted): {{camera}}({{camera_name}}), 
                             Base URL: {{'REDACTED' if base_url and redacted else base_url}}, 
-                            Frigate Base URL: {{'REDACTED' if frigate_url and redacted else frigate_url}},
                             critical: {{critical}}, 
                             tts: {{tts}} 
                             helper: {{tts_helper if tts else 'N/A'}},
@@ -1103,14 +1086,7 @@ action:
                            data:
                              target: "{{telegram_chat_id}}"
                              caption: "{{message}}"
-                             password: "{{ bearer_token if bearer_token else '' }}"
-                             authentication: "{{ 'bearer_token' if bearer_token else '' }}"
-                             url: >
-                               {% if bearer_token %}
-                                {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}
-                               {% else %}
-                                {{frigate_url}}/api/events/{{id}}/{{attachment}}
-                               {% endif %}
+                             url: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}"
                       - conditions: "{{ not notify_group_target }}"
                         sequence:
                           - device_id: !input notify_device
@@ -1469,14 +1445,7 @@ action:
                                         data:
                                           target: "{{telegram_chat_id}}"
                                           caption: "{{message}}"
-                                          password: "{{ bearer_token if bearer_token else '' }}"
-                                          authentication: "{{ 'bearer_token' if bearer_token else '' }}"
-                                          url: >
-                                            {% if bearer_token %}
-                                              {{ video }}
-                                            {% else %}
-                                              {{frigate_url}}/api/events/{{id}}/clip.mp4
-                                            {% endif %}
+                                          url: "{{ video }}"
                                           inline_keyboard:
                                             - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
                                             - [["{{button_3}}", "{{url_3}}"]]
@@ -1485,14 +1454,7 @@ action:
                                       data:
                                         target: "{{telegram_chat_id}}"
                                         caption: "{{message}}"
-                                        password: "{{ bearer_token if bearer_token else '' }}"
-                                        authentication: "{{ 'bearer_token' if bearer_token else '' }}"
-                                        url: >
-                                           {% if bearer_token %}
-                                            {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}
-                                           {% else %}
-                                            {{frigate_url}}/api/events/{{id}}/{{attachment}}
-                                           {% endif %}
+                                        url: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}"
                                         inline_keyboard:
                                           - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
                                           - [["{{button_3}}", "{{url_3}}"]]

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -117,6 +117,13 @@ blueprint:
         The API URL for downloading files for telegram integration.
         Required if Telegram Chat ID is set.
       default: ""
+    bearer_token:
+      name: Bearer token (Optional)
+      description: |
+        Bearer token is used instead of accessing API via unsecure ports.
+        Required if Telegram Chat ID is set.
+        Bearer token should be generated as HS256 JWT with Frigate JWT secret.
+      default: ""
     base_url:
       name: Base URL (Optional)
       description: |
@@ -863,7 +870,8 @@ variables:
   notify_group: !input notify_group
   notify_group_target: "{{ notify_group | lower | regex_replace('^notify\\.', '') | replace(' ','_') }}"
   telegram_chat_id: !input notify_telegram_chat_id
-  telegram: "{{true if ((telegram_chat_id | length > 0) and api_url) else ''}}"
+  bearer_token: !input bearer_token
+  telegram: "{{true if ((telegram_chat_id | length > 0) and (api_url or bearer_token)) else ''}}"
   zone_only: !input zone_filter
   input_zones: !input zones
   zones: "{{ input_zones }}"
@@ -1199,7 +1207,14 @@ action:
                            data:
                              target: "{{telegram_chat_id}}"
                              caption: "{{message}}"
-                             url: "{{api_url}}/api/events/{{id}}/{{attachment}}"
+                             password: "{{ bearer_token if bearer_token else '' }}"
+                             authentication: "{{ 'bearer_token' if bearer_token else '' }}"
+                             url: >
+                               {% if bearer_token %}
+                                {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}
+                               {% else %}
+                                {{api_url}}/api/events/{{id}}/{{attachment}}
+                               {% endif %}
                     default:
                       - service: "notify.{{ notify_group_target }}"
                         data:
@@ -1561,7 +1576,14 @@ action:
                                         data:
                                           target: "{{telegram_chat_id}}"
                                           caption: "{{message}}"
-                                          url: "{{api_url}}/api/events/{{id}}/clip.mp4"
+                                          password: "{{ bearer_token if bearer_token else '' }}"
+                                          authentication: "{{ 'bearer_token' if bearer_token else '' }}"
+                                          url: >
+                                            {% if bearer_token %}
+                                              {{ video }}
+                                            {% else %}
+                                              {{api_url}}/api/events/{{id}}/clip.mp4
+                                            {% endif %}
                                           inline_keyboard:
                                             - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
                                             - [["{{button_3}}", "{{url_3}}"]]
@@ -1570,7 +1592,14 @@ action:
                                       data:
                                         target: "{{telegram_chat_id}}"
                                         caption: "{{message}}"
-                                        url: "{{api_url}}/api/events/{{id}}/{{attachment}}"
+                                        password: "{{ bearer_token if bearer_token else '' }}"
+                                        authentication: "{{ 'bearer_token' if bearer_token else '' }}"
+                                        url: >
+                                           {% if bearer_token %}
+                                            {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{attachment}}
+                                           {% else %}
+                                            {{api_url}}/api/events/{{id}}/{{attachment}}
+                                           {% endif %}
                                         inline_keyboard:
                                           - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
                                           - [["{{button_3}}", "{{url_3}}"]]


### PR DESCRIPTION
I implemented telegram integration being inspired by https://github.com/SgtBatten/HA_blueprints/pull/38

I went with additional API URL since my base URL points to a reverse proxy which is using tailscale domain and it's unreachable from HA instance since it's not under tailscale. I do not find it problematic since API is already exposed for Frigate integration. This was never troublesome since those URLs that are constructed with base URL were never used directly for downloading which telegram bot does before sending to chat ID.

Would it be preferred to not use additional URL for this?

Edit:

I also realized we need a way to authenticate our telegram integration for the WebUI's API
This might outweight having additional API URL

Edit2:

Anyways I implemented bearer token auth also.

Edit3:

I also noticed that thumbnails/snapshots are sometimes unavailable over Web UI API, where they're persistent for longer over unprotected API.
I'm on latest frigate from master.