### PR TITLE
Fix critical notifications using interruption level.

### DIFF
--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -1323,7 +1323,7 @@ actions:
                                     sound:
                                       name: "{{sound}}"
                                       volume: "{{ iif(sound == 'none', 0, volume) }}"
-                                    interruption-level: "{{ iif(critical, 1, interruption_level) }}"
+                                    interruption-level: "{{ iif(critical, 'critical', interruption_level) }}"
                                   entity_id: "{{ios_live_view}}"
                                   # Actions
                                   actions:
@@ -1381,7 +1381,7 @@ actions:
                                       sound:
                                         name: "{{sound}}"
                                         volume: "{{ iif(sound == 'none', 0, volume) }}"
-                                      interruption-level: "{{ iif(critical, 1, interruption_level) }}"
+                                      interruption-level: "{{ iif(critical, 'critical', interruption_level) }}"
                                     entity_id: "{{ios_live_view}}"
                                     # Actions
                                     actions:
@@ -1436,7 +1436,7 @@ actions:
                                   sound:
                                     name: "{{sound}}"
                                     volume: "{{ iif(sound == 'none', 0, volume) }}"
-                                  interruption-level: "{{ iif(critical, 1, interruption_level) }}"
+                                  interruption-level: "{{ iif(critical, 'critical', interruption_level) }}"
                                 entity_id: "{{ios_live_view}}"
                                 # Actions
                                 actions:
@@ -1801,7 +1801,7 @@ actions:
                                           sound:
                                             name: "{{ iif(silent_update, 'none', sound) }}"
                                             volume: "{{ iif((silent_update or sound == 'none'), 0, volume) }}"
-                                          interruption-level: "{{ iif(critical, 1, interruption_level) }}"
+                                          interruption-level: "{{ iif(critical, 'critical', interruption_level) }}"
                                         entity_id: "{{ios_live_view}}"
                                         # Actions
                                         actions:
@@ -1860,7 +1860,7 @@ actions:
                                             sound:
                                               name: "{{ iif(silent_update, 'none', sound) }}"
                                               volume: "{{ iif((silent_update or sound == 'none'), 0, volume) }}"
-                                            interruption-level: "{{ iif(critical, 1, interruption_level) }}"
+                                            interruption-level: "{{ iif(critical, 'critical', interruption_level) }}"
                                           entity_id: "{{ios_live_view}}"
                                           # Actions
                                           actions:
@@ -1916,7 +1916,7 @@ actions:
                                         sound:
                                           name: "{{ iif(silent_update, 'none', sound) }}"
                                           volume: "{{ iif((silent_update or sound == 'none'), 0, volume) }}"
-                                        interruption-level: "{{ iif(critical, 1, interruption_level) }}"
+                                        interruption-level: "{{ iif(critical, 'critical', interruption_level) }}"
                                       entity_id: "{{ios_live_view}}"
                                       # Actions
                                       actions:


### PR DESCRIPTION
If critical notifications were triggered, the incorrect interruption_level of '1' would be used rather than 'critical'