### PR TITLE
Fix cooldown condition to prevent subtraction underflow

### DIFF
--- a/Frigate_Camera_Notifications/Stable.yaml
+++ b/Frigate_Camera_Notifications/Stable.yaml
@@ -1019,7 +1019,7 @@ conditions:
           condition: !input master_condition
         - alias: Cooldown
           condition: template
-          value_template: "{{ not this.attributes.last_triggered or (now() - this.attributes.last_triggered).seconds > cooldown }}"
+          value_template: "{{ not this.attributes.last_triggered or this.attributes.last_triggered + timedelta(seconds=cooldown) < now() }}"
         - alias: Disable Times
           condition: template
           value_template: "{{ not disable_times|length or not now().hour in disable_times|map('int')|list }}"


### PR DESCRIPTION
I had cooldown set to 0, but ran into cases where the cooldown condition was false and did not trigger a notification. I could only assume the clocks on my HA and frigate machines are out of sync and caused the subtraction to be a negative value, which is not less than 0, or that the last triggered time and `now()` were in the same second.

In any case, I think changing it this way makes it more bulletproof and uses higher precision than whole seconds to do the check.