### PR TITLE
Message updated with Frigate Gen AI

### DIFF
--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -1624,12 +1624,7 @@ actions:
                       {% endif %}
                     # import the title and message again so any sublabel, object or zone changes are captured.
                     title: !input title
-                    message: >-
-                      {% if wait.trigger.topic == 'frigate/tracked_object_update' and use_frigate_gen_ai %}
-                        {{ wait.trigger.payload_json.description }}
-                      {% else %}
-                        {{ message }}
-                      {% endif %}
+                    message: !input message
                     subtitle: !input subtitle
 
                     critical_input: !input critical


### PR DESCRIPTION
Blueprint now accepts the usage of Generative AI already integrated within Frigate. Achieved by listening to the topic "frigate/tracked_object_update" and reading the description.

Also added a boolean to don't use Gen Ai and keep using blueprint as previously.

Please suggest changes.