### PR TITLE
Update Frigate Notifications to include more GenAI options

### DIFF
--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -1,5 +1,5 @@
 blueprint:
-  name: Frigate Notifications (0.14.0.3l)
+  name: Frigate Notifications (0.14.0.4m-genai-custom)
   author: SgtBatten
   homeassistant:
     min_version: 2024.11.0
@@ -147,6 +147,8 @@ blueprint:
                   value: "{{ label }}{{ ' was' if type == 'end' else '' }} detected on the {{ camera_name }} camera{{' in the ' if after_zones|length}}{{ after_zones | join(', ') | replace('_', ' ' ) | title }}."
                 - label: "Long with a timestamp HH:MM"
                   value: "{{ label }}{{ ' was' if type == 'end' else '' }} detected on the {{ camera_name }} camera{{' in the ' if after_zones|length}}{{ after_zones | join(', ') | replace('_', ' ' ) | title }} at {{event['after']['start_time']|timestamp_custom('%H:%M')}}."
+                - label: "Doorbell Notification"
+                  value: "🔔 {{ label }}{{ ' was' if type == 'end' else ' is' }} at the {{ camera_name }}"
               custom_value: true
         update_sub_label:
           name: Update Sub Labels (Advanced)
@@ -183,6 +185,22 @@ blueprint:
             Must result in "passive", "active", "time-sensitive" or "critical" See https://companion.home-assistant.io/docs/notifications/notifications-basic#interruption-level for definitions
             Critical option above will override this setting when it is true
           default: "active"
+          selector:
+            select:
+              options:
+                - "passive"
+                - "active"
+                - "time-sensitive"
+                - "critical"
+                - "{{'critical' if now().hour in [8,9,10,11,12,13,14,15,16,17,18] else 'active'}}"
+                - "{{'time-sensitive' if is_state('sun.sun', 'above_horizon') else 'passive' }}"
+        interruption_level_updates:
+          name: Interruption Level for Updates (iOS)
+          description: |
+            Set the interruption level for updates on iOS devices. This can be templated.
+            Must result in "passive", "active", "time-sensitive" or "critical" See https://companion.home-assistant.io/docs/notifications/notifications-basic#interruption-level for definitions
+            Critical option above will override this setting when it is true
+          default: "passive"
           selector:
             select:
               options:
@@ -389,6 +407,11 @@ blueprint:
           name: Group
           description: The group name that will determine if notifications are grouped on your mobile device. If you want notifications grouped by camera, ensure it contains {{camera}}
           default: "{{camera}}-frigate-notification"
+          selector:
+            select:
+              options:
+                - "{{camera}}-frigate-notification"
+                - "{{camera}}-frigate-doorbell-notification"
         tag:
           name: Tag
           description: The Tag is used to identify individual notifications in order to replace them with updated images/text. Default is the Event ID 
@@ -610,6 +633,7 @@ blueprint:
             select:
               options:
                 - person
+                - visitor
                 - dog
                 - cat
                 - car
@@ -816,6 +840,10 @@ blueprint:
                   value: /ccab4aaf_frigate-fa/ingress
                 - label: Open Frigate (proxy)
                   value: /ccab4aaf_frigate-proxy/ingress
+                - label: View Stream (Frigate Ingress)
+                  value: /frigate?index=%23{{camera}}
+                - label: View Event (Frigate Ingress)
+                  value: /frigate?index=review?id={{review_id}}
                 - label: Open Reolink App (Android)
                   value: app://com.mcu.reolink
                 - label: None (Android)
@@ -856,6 +884,10 @@ blueprint:
                   value: /ccab4aaf_frigate-fa/ingress
                 - label: Open Frigate (proxy)
                   value: /ccab4aaf_frigate-proxy/ingress
+                - label: View Stream (Frigate Ingress)
+                  value: /frigate?index=%23{{camera}}
+                - label: View Event (Frigate Ingress)
+                  value: /frigate?index=review?id={{review_id}}
                 - label: Open Reolink App (Android)
                   value: app://com.mcu.reolink
                 - label: Custom Action (Manual Trigger)
@@ -896,6 +928,10 @@ blueprint:
                   value: /ccab4aaf_frigate-fa/ingress
                 - label: Open Frigate (proxy)
                   value: /ccab4aaf_frigate-proxy/ingress
+                - label: View Stream (Frigate Ingress)
+                  value: /frigate?index=%23{{camera}}
+                - label: View Event (Frigate Ingress)
+                  value: /frigate?index=review?id={{review_id}}
                 - label: Open Reolink App (Android)
                   value: app://com.mcu.reolink
                 - label: Custom Action (Manual Trigger)
@@ -936,6 +972,10 @@ blueprint:
                   value: /ccab4aaf_frigate-fa/ingress
                 - label: Open Frigate (proxy)
                   value: /ccab4aaf_frigate-proxy/ingress
+                - label: View Stream (Frigate Ingress)
+                  value: /frigate?index=%23{{camera}}
+                - label: View Event (Frigate Ingress)
+                  value: /frigate?index=review?id={{review_id}}
                 - label: Open Reolink App (Android)
                   value: app://com.mcu.reolink
                 - label: Custom Action (Manual Trigger)
@@ -1277,12 +1317,20 @@ actions:
               color: !input color
               sticky: !input sticky
               attachment: !input genai_sprinter_attachment
-              tap_action: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
-              button_1: View Clip
-              button_2: View Snapshot
-              url_1: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
-              url_2: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg"
-              url_3: "silence-{{ this.entity_id }}"
+              tap_action: !input tap_action
+              button_1: !input button_1
+              button_2: !input button_2
+              button_3: !input button_3
+              url_1: !input url_1
+              url_2: !input url_2
+              url_3: !input url_3
+              icon_1: !input icon_1
+              icon_2: !input icon_2
+              icon_3: !input icon_3
+              critical_input: !input critical
+              critical: "{{ true if critical_input == 'true' else true if critical_input == True else false }}"
+              interruption_level_updates: !input interruption_level_updates
+              sound: !input sound
               ios_live_view: !input ios_live_view
               android_auto: !input android_auto
               tv: !input tv
@@ -1312,7 +1360,7 @@ actions:
                               url: "{{attachment|replace(base_url, telegram_base_url)}}"
                               inline_keyboard:
                                 - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
-                                - [["Silence {{ silence_minutes }}m", "{{url_3}}"]]
+                                - [["{{button_3}}", "{{url_3}}"]]
                     default:
                       - service: "{{ telegram_photo_service }}"
                         data:
@@ -1321,7 +1369,7 @@ actions:
                           url: "{{attachment|replace(base_url, telegram_base_url)}}"
                           inline_keyboard:
                             - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
-                            - [["Silence {{ silence_minutes }}m", "{{url_3}}"]]
+                            - [["{{button_3}}", "{{url_3}}"]]
               - conditions: "{{ not notify_group_target }}"
                 sequence:
                   - device_id: !input notify_device
@@ -1338,10 +1386,10 @@ actions:
                       clickAction: "{{tap_action}}"
                       ttl: 0
                       priority: high
-                      alert_once: true
+                      alert_once: "{{ alert_once }}"
                       notification_icon: "{{icon}}"
                       sticky: "{{sticky}}"
-                      channel: "{{channel}}"
+                      channel: "{{'alarm_stream' if critical else channel}}"
                       car_ui: "{{android_auto}}"
                       subtitle: "{{subtitle}}"
                       url: "{{tap_action}}"
@@ -1353,17 +1401,24 @@ actions:
                         sound:
                           name: none
                           volume: 0
-                        interruption-level: passive
+                        interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
                       entity_id: "{{ios_live_view}}"
                       actions:
-                        - action: URI
+                        - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
                           title: "{{button_1}}"
                           uri: "{{url_1}}"
-                        - action: URI
+                          icon: "{{icon_1}}"
+                          destructive: "{{not '/' in url_1}}"
+                        - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
                           title: "{{button_2}}"
                           uri: "{{url_2}}"
-                        - action: "{{url_3}}"
-                          title: "Silence {{ silence_minutes }}m"
+                          icon: "{{icon_2}}"
+                          destructive: "{{not '/' in url_2}}"
+                        - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                          title: "{{button_3}}"
+                          uri: "{{url_3}}"
+                          icon: "{{icon_3}}"
+                          destructive: "{{not '/' in url_3}}"
               - conditions: "{{ tv }}"
                 sequence:
                   - action: "notify.{{ notify_group_target }}"
@@ -1378,10 +1433,10 @@ actions:
                         clickAction: "{{tap_action}}"
                         ttl: 0
                         priority: high
-                        alert_once: true
+                        alert_once: "{{ alert_once }}"
                         notification_icon: "{{icon}}"
                         sticky: "{{sticky}}"
-                        channel: "{{channel}}"
+                        channel: "{{'alarm_stream' if critical else channel}}"
                         car_ui: "{{android_auto}}"
                         image:
                           url: "{{tv_image}}"
@@ -1401,17 +1456,24 @@ actions:
                           sound:
                             name: none
                             volume: 0
-                          interruption-level: passive
+                          interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
                         entity_id: "{{ios_live_view}}"
                         actions:
-                          - action: URI
+                          - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
                             title: "{{button_1}}"
                             uri: "{{url_1}}"
-                          - action: URI
+                            icon: "{{icon_1}}"
+                            destructive: "{{not '/' in url_1}}"
+                          - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
                             title: "{{button_2}}"
                             uri: "{{url_2}}"
-                          - action: "{{url_3}}"
-                            title: "Silence {{ silence_minutes }}m"
+                            icon: "{{icon_2}}"
+                            destructive: "{{not '/' in url_2}}"
+                          - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                            title: "{{button_3}}"
+                            uri: "{{url_3}}"
+                            icon: "{{icon_3}}"
+                            destructive: "{{not '/' in url_3}}"
             default:
               - action: "notify.{{ notify_group_target }}"
                 data:
@@ -1426,10 +1488,10 @@ actions:
                     clickAction: "{{tap_action}}"
                     ttl: 0
                     priority: high
-                    alert_once: true
+                    alert_once: "{{ alert_once }}"
                     notification_icon: "{{icon}}"
                     sticky: "{{sticky}}"
-                    channel: "{{channel}}"
+                    channel: "{{'alarm_stream' if critical else channel}}"
                     car_ui: "{{android_auto}}"
                     subtitle: "{{subtitle}}"
                     fontsize: "{{tv_size}}"
@@ -1446,17 +1508,24 @@ actions:
                       sound:
                         name: none
                         volume: 0
-                      interruption-level: passive
+                      interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
                     entity_id: "{{ios_live_view}}"
                     actions:
-                      - action: URI
+                      - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
                         title: "{{button_1}}"
                         uri: "{{url_1}}"
-                      - action: URI
+                        icon: "{{icon_1}}"
+                        destructive: "{{not '/' in url_1}}"
+                      - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
                         title: "{{button_2}}"
                         uri: "{{url_2}}"
-                      - action: "{{url_3}}"
-                        title: "Silence {{ silence_minutes }}m"
+                        icon: "{{icon_2}}"
+                        destructive: "{{not '/' in url_2}}"
+                      - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                        title: "{{button_3}}"
+                        uri: "{{url_3}}"
+                        icon: "{{icon_3}}"
+                        destructive: "{{not '/' in url_3}}"
       - alias: "Final GenAI Review Summary"
         conditions:
           - condition: trigger
@@ -1513,12 +1582,20 @@ actions:
               color: !input color
               sticky: !input sticky
               attachment: !input genai_final_attachment
-              tap_action: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
-              button_1: View Clip
-              button_2: View Snapshot
-              url_1: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
-              url_2: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg"
-              url_3: "silence-{{ this.entity_id }}"
+              tap_action: !input tap_action
+              button_1: !input button_1
+              button_2: !input button_2
+              button_3: !input button_3
+              url_1: !input url_1
+              url_2: !input url_2
+              url_3: !input url_3
+              icon_1: !input icon_1
+              icon_2: !input icon_2
+              icon_3: !input icon_3
+              critical_input: !input critical
+              critical: "{{ true if critical_input == 'true' else true if critical_input == True else false }}"
+              interruption_level_updates: !input interruption_level_updates
+              sound: !input sound
               ios_live_view: !input ios_live_view
               android_auto: !input android_auto
               tv: !input tv
@@ -1558,7 +1635,7 @@ actions:
                                       url: "{{attachment|replace(base_url, telegram_base_url)}}"
                                       inline_keyboard:
                                         - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
-                                        - [["Silence {{ silence_minutes }}m", "{{url_3}}"]]
+                                        - [["{{button_3}}", "{{url_3}}"]]
                             default:
                               - service: "{{ telegram_photo_service }}"
                                 data:
@@ -1567,7 +1644,7 @@ actions:
                                   url: "{{attachment|replace(base_url, telegram_base_url)}}"
                                   inline_keyboard:
                                     - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
-                                    - [["Silence {{ silence_minutes }}m", "{{url_3}}"]]
+                                    - [["{{button_3}}", "{{url_3}}"]]
                       - conditions: "{{ not notify_group_target }}"
                         sequence:
                           - device_id: !input notify_device
@@ -1584,10 +1661,10 @@ actions:
                               clickAction: "{{tap_action}}"
                               ttl: 0
                               priority: high
-                              alert_once: true
+                              alert_once: "{{ alert_once }}"
                               notification_icon: "{{icon}}"
                               sticky: "{{sticky}}"
-                              channel: "{{channel}}"
+                              channel: "{{'alarm_stream' if critical else channel}}"
                               car_ui: "{{android_auto}}"
                               subtitle: "{{subtitle}}"
                               url: "{{tap_action}}"
@@ -1599,17 +1676,24 @@ actions:
                                 sound:
                                   name: none
                                   volume: 0
-                                interruption-level: passive
+                                interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
                               entity_id: "{{ios_live_view}}"
                               actions:
-                                - action: URI
+                                - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
                                   title: "{{button_1}}"
                                   uri: "{{url_1}}"
-                                - action: URI
+                                  icon: "{{icon_1}}"
+                                  destructive: "{{not '/' in url_1}}"
+                                - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
                                   title: "{{button_2}}"
                                   uri: "{{url_2}}"
-                                - action: "{{url_3}}"
-                                  title: "Silence {{ silence_minutes }}m"
+                                  icon: "{{icon_2}}"
+                                  destructive: "{{not '/' in url_2}}"
+                                - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                  title: "{{button_3}}"
+                                  uri: "{{url_3}}"
+                                  icon: "{{icon_3}}"
+                                  destructive: "{{not '/' in url_3}}"
                       - conditions: "{{ tv }}"
                         sequence:
                           - action: "notify.{{ notify_group_target }}"
@@ -1624,10 +1708,10 @@ actions:
                                 clickAction: "{{tap_action}}"
                                 ttl: 0
                                 priority: high
-                                alert_once: true
+                                alert_once: "{{ alert_once }}"
                                 notification_icon: "{{icon}}"
                                 sticky: "{{sticky}}"
-                                channel: "{{channel}}"
+                                channel: "{{'alarm_stream' if critical else channel}}"
                                 car_ui: "{{android_auto}}"
                                 image:
                                   url: "{{tv_image}}"
@@ -1647,17 +1731,24 @@ actions:
                                   sound:
                                     name: none
                                     volume: 0
-                                  interruption-level: passive
+                                  interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
                                 entity_id: "{{ios_live_view}}"
                                 actions:
-                                  - action: URI
+                                  - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
                                     title: "{{button_1}}"
                                     uri: "{{url_1}}"
-                                  - action: URI
+                                    icon: "{{icon_1}}"
+                                    destructive: "{{not '/' in url_1}}"
+                                  - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
                                     title: "{{button_2}}"
                                     uri: "{{url_2}}"
-                                  - action: "{{url_3}}"
-                                    title: "Silence {{ silence_minutes }}m"
+                                    icon: "{{icon_2}}"
+                                    destructive: "{{not '/' in url_2}}"
+                                  - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                    title: "{{button_3}}"
+                                    uri: "{{url_3}}"
+                                    icon: "{{icon_3}}"
+                                    destructive: "{{not '/' in url_3}}"
                     default:
                       - action: "notify.{{ notify_group_target }}"
                         data:
@@ -1672,10 +1763,10 @@ actions:
                             clickAction: "{{tap_action}}"
                             ttl: 0
                             priority: high
-                            alert_once: true
+                            alert_once: "{{ alert_once }}"
                             notification_icon: "{{icon}}"
                             sticky: "{{sticky}}"
-                            channel: "{{channel}}"
+                            channel: "{{'alarm_stream' if critical else channel}}"
                             car_ui: "{{android_auto}}"
                             subtitle: "{{subtitle}}"
                             fontsize: "{{tv_size}}"
@@ -1692,17 +1783,24 @@ actions:
                               sound:
                                 name: none
                                 volume: 0
-                              interruption-level: passive
+                              interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
                             entity_id: "{{ios_live_view}}"
                             actions:
-                              - action: URI
+                              - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
                                 title: "{{button_1}}"
                                 uri: "{{url_1}}"
-                              - action: URI
+                                icon: "{{icon_1}}"
+                                destructive: "{{not '/' in url_1}}"
+                              - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
                                 title: "{{button_2}}"
                                 uri: "{{url_2}}"
-                              - action: "{{url_3}}"
-                                title: "Silence {{ silence_minutes }}m"
+                                icon: "{{icon_2}}"
+                                destructive: "{{not '/' in url_2}}"
+                              - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                title: "{{button_3}}"
+                                uri: "{{url_3}}"
+                                icon: "{{icon_3}}"
+                                destructive: "{{not '/' in url_3}}"
       - alias: "Frigate Event"
         conditions:
           - condition: trigger
@@ -2223,6 +2321,7 @@ actions:
                     critical_input: !input critical
                     critical: "{{ true if critical_input == 'true' else true if critical_input == True else false }}"
                     interruption_level: !input interruption_level
+                    interruption_level_updates: !input interruption_level_updates
                     tts: !input tts
 
                     sub_label_updated: "{{ update_sub_label and sub_labels != before_sub_labels }}"
@@ -2252,6 +2351,7 @@ actions:
                                   Message: {{message}}
                                   iOS sound: {{'Critical' if critical else 'disabled by alert once' if alert_once else 'Silent' if silent_update else sound}},
                                   iOS Interruption Level: {{interruption_level}}
+                                  iOS Interruption for Updates Level: {{interruption_level_updates}}
                                   Android Sound: {{'disabled by alert once' if alert_once else 'enabled'}},
                                   iOS url: "{{(video if not redacted or not base_url else video |replace(base_url, 'REDACTED')) if video else attachment if not redacted or not base_url else attachment |replace(base_url, 'REDACTED')}}", 
                                   Video: "{{video if not redacted or not base_url else video |replace(base_url, 'REDACTED')}}", 
@@ -2429,7 +2529,7 @@ actions:
                                           sound:
                                             name: "{{ iif(silent_update, 'none', sound) }}"
                                             volume: "{{ iif((silent_update or sound == 'none'), 0, volume) }}"
-                                          interruption-level: "{{ iif(critical, 1, interruption_level) }}"
+                                          interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
                                         entity_id: "{{ios_live_view}}"
                                         # Actions
                                         actions:
@@ -2488,7 +2588,7 @@ actions:
                                             sound:
                                               name: "{{ iif(silent_update, 'none', sound) }}"
                                               volume: "{{ iif((silent_update or sound == 'none'), 0, volume) }}"
-                                            interruption-level: "{{ iif(critical, 1, interruption_level) }}"
+                                            interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
                                           entity_id: "{{ios_live_view}}"
                                           # Actions
                                           actions:
@@ -2544,7 +2644,7 @@ actions:
                                         sound:
                                           name: "{{ iif(silent_update, 'none', sound) }}"
                                           volume: "{{ iif((silent_update or sound == 'none'), 0, volume) }}"
-                                        interruption-level: "{{ iif(critical, 1, interruption_level) }}"
+                                        interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
                                       entity_id: "{{ios_live_view}}"
                                       # Actions
                                       actions:

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -1,5 +1,5 @@
 blueprint:
-  name: Frigate Notifications (0.14.0.3k)
+  name: Frigate Notifications (0.14.0.3l)
   author: SgtBatten
   homeassistant:
     min_version: 2024.11.0
@@ -22,7 +22,8 @@ blueprint:
 
     ### Features:
       - Easily select the camera entities or mobile device using a drop-down menu.
-      - Configure multiple cameras in one automation. 
+      - Configure multiple cameras in one automation.
+      - Optional Sprinter and Final GenAI notification updates with separate attachment and description toggles.
 
       For the full features list visit the [GitHub Repository][1]
 
@@ -54,6 +55,15 @@ blueprint:
         device:
           filter:
             integration: mobile_app
+    notify_all_devices:
+      name: Notify All Devices
+      description: |
+        Send notifications via notify.notify instead of a single mobile device.
+
+        If enabled, this overrides the Mobile Device option, but Notification Group / Android/Fire TV below will still take priority when set.
+      default: false
+      selector:
+        boolean:
     notify_group:
       name: Notification Group or Android/Fire TV (Optional)
       description: |
@@ -253,7 +263,7 @@ blueprint:
             select:
               options:
                 - label: None
-                  value: ""
+                  value: "none"
                 # format=android converts it to a 2:1 ratio for mobile display.
                 - label: Thumbnail
                   value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/thumbnail.jpg"
@@ -429,6 +439,105 @@ blueprint:
           name: Notification Channel - Android only (Optional)
           description: Create a new channel for notifications to allow custom notification sounds, vibration patterns, and override of Do Not Disturb mode. Configured directly on the device.
           default: ""
+    genai_updates:
+      name: |
+        # GenAI Updates
+      description: These are optional GenAI update options
+      icon: mdi:robot
+      collapsed: true
+      input:
+        genai_sprinter:
+          name: Enable Sprinter GenAI Update
+          description: |
+            Update the existing notification when Frigate publishes a tracked object description on `frigate/tracked_object_update`.
+
+            This update is sent silently to avoid repeated buzzes.
+          default: false
+          selector:
+            boolean:
+        genai_sprinter_description:
+          name: Include Sprinter Description
+          description: Include the tracked object description text in the Sprinter update message body.
+          default: true
+          selector:
+            boolean:
+        genai_sprinter_attachment:
+          name: Sprinter Attachment
+          description: Choose which media to attach to the Sprinter update.
+          default: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/event_preview.gif"
+          selector:
+            select:
+              options:
+                - label: Thumbnail
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/thumbnail.jpg"
+                - label: Snapshot
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg"
+                - label: Snapshot with bounding box
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?bbox=1"
+                - label: Snapshot cropped
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?crop=1"
+                - label: Snapshot cropped with bounding box
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?bbox=1&crop=1"
+                - label: Object 1 Event GIF
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/event_preview.gif"
+                - label: Thumbnail (2:1)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/thumbnail.jpg?format=android"
+                - label: Snapshot (2:1)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?format=android"
+                - label: Snapshot with bounding box (2:1)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?bbox=1&format=android"
+                - label: Snapshot cropped (2:1)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?crop=1&format=android"
+                - label: Snapshot cropped with bounding box (2:1)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?bbox=1&crop=1&format=android"
+              mode: dropdown
+        genai_final:
+          name: Enable Final GenAI Review Summary
+          description: |
+            Update the existing notification when Frigate publishes a review-summary GenAI message on the reviews topic.
+
+            Requires Frigate review summaries.
+          default: false
+          selector:
+            boolean:
+        genai_final_description:
+          name: Include Final Description
+          description: Include the final GenAI review summary text in the update message body.
+          default: true
+          selector:
+            boolean:
+        genai_final_attachment:
+          name: Final GenAI Attachment
+          description: Choose which media to attach to the Final GenAI update.
+          default: "{{base_url}}/api/frigate{{client_id}}/notifications/{{review_id}}/review_preview.gif"
+          selector:
+            select:
+              options:
+                - label: Thumbnail
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/thumbnail.jpg"
+                - label: Snapshot
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg"
+                - label: Snapshot with bounding box
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?bbox=1"
+                - label: Snapshot cropped
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?crop=1"
+                - label: Snapshot cropped with bounding box
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?bbox=1&crop=1"
+                - label: Review GIF
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{review_id}}/review_preview.gif"
+                - label: Object 1 Event GIF
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/event_preview.gif"
+                - label: Thumbnail (2:1)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/thumbnail.jpg?format=android"
+                - label: Snapshot (2:1)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?format=android"
+                - label: Snapshot with bounding box (2:1)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?bbox=1&format=android"
+                - label: Snapshot cropped (2:1)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?crop=1&format=android"
+                - label: Snapshot cropped with bounding box (2:1)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg?bbox=1&crop=1&format=android"
+              mode: dropdown
     filters:
       name: |
         # Filters
@@ -955,10 +1064,13 @@ triggers:
     value_template: "{{value_json['type']}}"
     id: frigate-event
   - trigger: mqtt
+    topic: frigate/tracked_object_update
+    id: genai-sprinter
+  - trigger: mqtt
     topic: "{{mqtt_topic}}"
     payload: genai
     value_template: "{{value_json['type']}}"
-    id: genai-event
+    id: genai-final
   - trigger: event
     event_type: mobile_app_notification_action
     event_data:
@@ -982,11 +1094,18 @@ triggers:
 variables:
   input_camera: !input camera
   input_camera_name: "{{input_camera|expand|map(attribute='attributes.camera_name', default='none')|list}}"
-  camera: "{{trigger.payload_json['after']['camera'] if trigger.id == 'frigate-event'}}"
+  camera: >
+    {% if trigger.id == 'frigate-event' %}
+      {{ trigger.payload_json['after']['camera'] }}
+    {% elif trigger.id == 'genai-sprinter' %}
+      {{ trigger.payload_json['camera'] }}
+    {% elif trigger.id == 'genai-final' %}
+      {{ trigger.payload_json['after']['camera'] }}
+    {% endif %}
   camera_name: "{{ camera | replace('_', ' ') | title }}"
   input_severity: !input review_severity
   severity: "{{trigger.payload_json['after']['severity'] if trigger.id == 'frigate-event'}}"
-  type: "{{trigger.payload_json['type'] if trigger.id == 'frigate-event'}}"
+  type: "{{trigger.payload_json['type'] if trigger.id in ['frigate-event', 'genai-sprinter', 'genai-final']}}"
   input_base_url: !input base_url
   base_url: "{{ input_base_url.rstrip('/')}}"
   input_telegram_base_url: !input telegram_base_url
@@ -996,12 +1115,27 @@ variables:
   client_id: "{{input_client_id if not input_client_id else '/' + input_client_id if '/' not in input_client_id else input_client_id }}"
   alert_once: !input alert_once
   final_update: !input final_update
+  genai_sprinter: !input genai_sprinter
+  genai_sprinter_description: !input genai_sprinter_description
+  genai_sprinter_attachment: !input genai_sprinter_attachment
+  genai_final: !input genai_final
+  genai_final_description: !input genai_final_description
+  genai_final_attachment: !input genai_final_attachment
   ios_live_view: !input ios_live_view
   android_auto: !input android_auto
+  notify_all_devices: !input notify_all_devices
   notify_group: !input notify_group
-  notify_group_target: "{{ notify_group | lower | regex_replace('^notify\\.', '') | replace(' ','_') }}"
+  notify_group_target: >
+    {% if notify_all_devices and not notify_group %}
+      notify
+    {% else %}
+      {{ notify_group | lower | regex_replace('^notify\.', '') | replace(' ','_') }}
+    {% endif %}
   telegram_chat_id: !input notify_telegram_chat_id
   telegram: "{{true if (telegram_chat_id | length > 0) else false}}"
+  telegram_photo_service: "{{ 'telegram_bot' ~ '.send_photo' }}"
+  telegram_animation_service: "{{ 'telegram_bot' ~ '.send_animation' }}"
+  telegram_video_service: "{{ 'telegram_bot' ~ '.send_video' }}"
   zone_only: !input zone_filter
   input_zones: !input zones
   zones: "{{ input_zones | list | lower }}"
@@ -1013,6 +1147,7 @@ variables:
   disable_times: !input disable_times
   cooldown: !input cooldown
   timeout: !input timeout
+  silence_minutes: !input silence_timer
   loitering: false
   loiter_timer: !input loiter_timer
   initial_delay: !input initial_delay
@@ -1053,8 +1188,36 @@ conditions:
       id: silence
     - condition: trigger
       id: custom
-    - condition: trigger
-      id: genai-event
+    - condition: and
+      conditions:
+        - condition: trigger
+          id: genai-sprinter
+        - alias: Sprinter Enabled
+          condition: template
+          value_template: "{{ genai_sprinter }}"
+        - alias: Sprinter Type Match
+          condition: template
+          value_template: "{{ type == 'description' }}"
+        - alias: Camera Match
+          condition: template
+          value_template: "{{ input_camera_name|select('equalto', camera)|list|length>0 }}"
+        - alias: Master Condition
+          condition: !input master_condition
+    - condition: and
+      conditions:
+        - condition: trigger
+          id: genai-final
+        - alias: Final GenAI Enabled
+          condition: template
+          value_template: "{{ genai_final }}"
+        - alias: Final Type Match
+          condition: template
+          value_template: "{{ type == 'genai' }}"
+        - alias: Camera Match
+          condition: template
+          value_template: "{{ input_camera_name|select('equalto', camera)|list|length>0 }}"
+        - alias: Master Condition
+          condition: !input master_condition
     - condition: and
       conditions:
         - condition: trigger
@@ -1092,50 +1255,34 @@ actions:
           - condition: trigger
             id: custom
         sequence: !input "custom_action_manual"
-      - alias: "GenAI Summary"
+      - alias: "GenAI Sprinter Update"
         conditions:
           - condition: trigger
-            id: "genai-event"
+            id: genai-sprinter
+          - "{{ genai_sprinter }}"
+          - "{{ type == 'description' }}"
+          - "{{ input_camera_name|select('equalto', camera)|list|length>0 }}"
         sequence:
           - variables:
-              event: "{{ trigger.payload_json }}"
-              detections: "{{ event['after']['data']['detections'] }}"
-              review_id: "{{ event['after']['id'] }}"
-              id: "{{ detections[0] }}"
-              metadata: "{{ event['after']['data']['metadata'] | default({}) }}"
-              genai_title: "{{ metadata.title | default('') }}"
-              genai_shortSummary: "{{ metadata.shortSummary | default('') }}"
-              genai_threat_level: "{{ metadata.potential_threat_level | int(0) }}"
-              title: >-
-                {% if genai_threat_level == 2 %}
-                  Security Concern: {{ genai_title }}
-                {% elif genai_threat_level == 1 %}
-                  Needs Review: {{ genai_title }}
-                {% else %}
-                  {{ genai_title }}
-                {% endif %}
-              message: "{{ genai_shortSummary }}"
+              id: "{{ trigger.payload_json['id'] }}"
+              review_id: "{{ trigger.payload_json.get('review_id', trigger.payload_json['id']) }}"
+              label: "{{ trigger.payload_json.get('label', 'GenAI') | replace('_', ' ') | title }}"
+              title: "Detection at {{ trigger.payload_json['camera'] | replace('_', ' ') | title }}"
+              message: "{{ trigger.payload_json['description'] if genai_sprinter_description else '' }}"
               subtitle: !input subtitle
-              critical_input: !input critical
-              critical: "{{ true if critical_input == 'true' else true if critical_input == True else false }}"
-              interruption_level: !input interruption_level
               icon: !input icon
               group: !input group
-              tag: "{{ review_id }}"
+              tag: !input tag
               channel: !input channel
               color: !input color
               sticky: !input sticky
-              sound: !input sound
-              tap_action: !input tap_action
-              button_1: !input button_1
-              button_2: !input button_2
-              button_3: !input button_3
-              url_1: !input url_1
-              url_2: !input url_2
-              url_3: !input url_3
-              icon_1: !input icon_1
-              icon_2: !input icon_2
-              icon_3: !input icon_3
+              attachment: !input genai_sprinter_attachment
+              tap_action: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
+              button_1: View Clip
+              button_2: View Snapshot
+              url_1: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
+              url_2: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg"
+              url_3: "silence-{{ this.entity_id }}"
               ios_live_view: !input ios_live_view
               android_auto: !input android_auto
               tv: !input tv
@@ -1144,128 +1291,81 @@ actions:
               tv_duration: !input tv_duration
               tv_transparency: !input tv_transparency
               tv_interrupt: !input tv_interrupt
-              attachment: !input attachment
-              video: !input video
-          - alias: "Send GenAI Notification"
-            sequence:
-              - choose:
-                  - conditions: "{{ telegram }}"
-                    sequence:
-                      - action: telegram_bot.send_photo
+              tv_image: >
+                {% if 'event_preview.gif' in attachment %}
+                  {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg
+                {% else %}
+                  {{attachment}}
+                {% endif %}
+              telegram_caption: "{{ title ~ ('\n' ~ message if message else '') }}"
+              attachment_content_type: "{{ 'jpeg' if 'jpg' in attachment else 'gif' }}"
+          - choose:
+              - conditions: "{{ telegram }}"
+                sequence:
+                  - choose:
+                      - conditions: "{{ 'gif' in attachment }}"
+                        sequence:
+                          - service: "{{ telegram_animation_service }}"
+                            data:
+                              chat_id: "{{telegram_chat_id}}"
+                              caption: "{{telegram_caption}}"
+                              url: "{{attachment|replace(base_url, telegram_base_url)}}"
+                              inline_keyboard:
+                                - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
+                                - [["Silence {{ silence_minutes }}m", "{{url_3}}"]]
+                    default:
+                      - service: "{{ telegram_photo_service }}"
                         data:
                           chat_id: "{{telegram_chat_id}}"
-                          caption: "{{message}}"
-                          url: "{{attachment|replace( base_url, telegram_base_url )}}"
-                  - conditions: "{{ not notify_group_target }}"
-                    sequence:
-                      - device_id: !input notify_device
-                        domain: mobile_app
-                        type: notify
-                        title: "{{title}}"
-                        message: "{{message}}"
-                        data:
-                          tag: "{{ tag }}"
-                          group: "{{ group }}"
-                          color: "{{color}}"
-                          # Android Specific
-                          subject: "{{subtitle}}"
-                          image: "{{attachment}}"
-                          video: "{{video}}"
-                          clickAction: "{{tap_action}}"
-                          ttl: 0
-                          priority: high
-                          notification_icon: "{{icon}}"
-                          sticky: "{{sticky}}"
-                          channel: "{{'alarm_stream' if critical else channel}}"
-                          car_ui: "{{android_auto}}"
-                          # iOS Specific
-                          subtitle: "{{subtitle}}"
-                          url: "{{tap_action}}"
-                          attachment:
-                            url: "{{video if video else attachment }}"
-                            content-type: "{{ 'application/vnd.apple.mpegurl' if 'm3u8' in video else 'mp4' if 'mp4' in video else 'jpeg' if 'jpg' in attachment else 'gif' }}"
-                          push:
-                            sound:
-                              name: "{{sound}}"
-                              volume: "{{ iif(sound == 'none', 0, volume) }}"
-                            interruption-level: "{{ iif(critical, 1, interruption_level) }}"
-                          entity_id: "{{ios_live_view}}"
-                          # Actions
-                          actions:
-                            - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
-                              title: "{{button_1}}"
-                              uri: "{{url_1}}"
-                              icon: "{{icon_1}}"
-                              destructive: "{{not '/' in url_1}}"
-                            - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
-                              title: "{{button_2}}"
-                              uri: "{{url_2}}"
-                              icon: "{{icon_2}}"
-                              destructive: "{{not '/' in url_2}}"
-                            - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
-                              title: "{{button_3}}"
-                              uri: "{{url_3}}"
-                              icon: "{{icon_3}}"
-                              destructive: "{{not '/' in url_3}}"
-                  - conditions: "{{ tv }}"
-                    sequence:
-                      - action: "notify.{{ notify_group_target }}"
-                        data:
-                          title: "{{title}}"
-                          message: "{{message}}"
-                          data:
-                            tag: "{{ tag }}"
-                            group: "{{ group }}"
-                            color: "{{color}}"
-                            # Android Specific
-                            subject: "{{subtitle}}"
-                            clickAction: "{{tap_action}}"
-                            ttl: 0
-                            priority: high
-                            notification_icon: "{{icon}}"
-                            sticky: "{{sticky}}"
-                            channel: "{{'alarm_stream' if critical else channel}}"
-                            car_ui: "{{android_auto}}"
-                            # Android/Fire TV
-                            image:
-                              #only send still images to TV
-                              url: "{{attachment | replace('review_preview.gif','snapshot.jpg') | replace('event_preview.gif','snapshot.jpg')}}"
-                            fontsize: "{{tv_size}}"
-                            position: "{{tv_position}}"
-                            duration: "{{tv_duration}}"
-                            transparency: "{{tv_transparency}}"
-                            interrupt: "{{tv_interrupt}}"
-                            timeout: 30
-                            # iOS Specific
-                            subtitle: "{{subtitle}}"
-                            url: "{{tap_action}}"
-                            attachment:
-                              url: "{{video if video else attachment }}"
-                              content-type: "{{ 'application/vnd.apple.mpegurl' if 'm3u8' in video else 'mp4' if 'mp4' in video else 'jpeg' if 'jpg' in attachment else 'gif' }}"
-                            push:
-                              sound:
-                                name: "{{sound}}"
-                                volume: "{{ iif(sound == 'none', 0, volume) }}"
-                              interruption-level: "{{ iif(critical, 1, interruption_level) }}"
-                            entity_id: "{{ios_live_view}}"
-                            # Actions
-                            actions:
-                              - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
-                                title: "{{button_1}}"
-                                uri: "{{url_1}}"
-                                icon: "{{icon_1}}"
-                                destructive: "{{not '/' in url_1}}"
-                              - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
-                                title: "{{button_2}}"
-                                uri: "{{url_2}}"
-                                icon: "{{icon_2}}"
-                                destructive: "{{not '/' in url_2}}"
-                              - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
-                                title: "{{button_3}}"
-                                uri: "{{url_3}}"
-                                icon: "{{icon_3}}"
-                                destructive: "{{not '/' in url_3}}"
-                default:
+                          caption: "{{telegram_caption}}"
+                          url: "{{attachment|replace(base_url, telegram_base_url)}}"
+                          inline_keyboard:
+                            - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
+                            - [["Silence {{ silence_minutes }}m", "{{url_3}}"]]
+              - conditions: "{{ not notify_group_target }}"
+                sequence:
+                  - device_id: !input notify_device
+                    domain: mobile_app
+                    type: notify
+                    title: "{{title}}"
+                    message: "{{message}}"
+                    data:
+                      tag: "{{ tag }}"
+                      group: "{{ group }}"
+                      color: "{{color}}"
+                      subject: "{{subtitle}}"
+                      image: "{{attachment}}"
+                      clickAction: "{{tap_action}}"
+                      ttl: 0
+                      priority: high
+                      alert_once: true
+                      notification_icon: "{{icon}}"
+                      sticky: "{{sticky}}"
+                      channel: "{{channel}}"
+                      car_ui: "{{android_auto}}"
+                      subtitle: "{{subtitle}}"
+                      url: "{{tap_action}}"
+                      attachment:
+                        url: "{{attachment}}"
+                        content-type: "{{attachment_content_type}}"
+                        hide-thumbnail: false
+                      push:
+                        sound:
+                          name: none
+                          volume: 0
+                        interruption-level: passive
+                      entity_id: "{{ios_live_view}}"
+                      actions:
+                        - action: URI
+                          title: "{{button_1}}"
+                          uri: "{{url_1}}"
+                        - action: URI
+                          title: "{{button_2}}"
+                          uri: "{{url_2}}"
+                        - action: "{{url_3}}"
+                          title: "Silence {{ silence_minutes }}m"
+              - conditions: "{{ tv }}"
+                sequence:
                   - action: "notify.{{ notify_group_target }}"
                     data:
                       title: "{{title}}"
@@ -1274,52 +1374,335 @@ actions:
                         tag: "{{ tag }}"
                         group: "{{ group }}"
                         color: "{{color}}"
-                        # Android Specific
                         subject: "{{subtitle}}"
-                        image: "{{attachment}}"
-                        video: "{{video}}"
                         clickAction: "{{tap_action}}"
                         ttl: 0
                         priority: high
+                        alert_once: true
                         notification_icon: "{{icon}}"
                         sticky: "{{sticky}}"
-                        channel: "{{'alarm_stream' if critical else channel}}"
+                        channel: "{{channel}}"
                         car_ui: "{{android_auto}}"
-                        # Android/Fire TV
-                        subtitle: "{{subtitle}}"
+                        image:
+                          url: "{{tv_image}}"
                         fontsize: "{{tv_size}}"
                         position: "{{tv_position}}"
                         duration: "{{tv_duration}}"
                         transparency: "{{tv_transparency}}"
                         interrupt: "{{tv_interrupt}}"
-                        # iOS Specific
+                        timeout: 30
+                        subtitle: "{{subtitle}}"
                         url: "{{tap_action}}"
                         attachment:
-                          url: "{{video if video else attachment }}"
-                          content-type: "{{ 'application/vnd.apple.mpegurl' if 'm3u8' in video else 'mp4' if 'mp4' in video else 'jpeg' if 'jpg' in attachment else 'gif' }}"
+                          url: "{{attachment}}"
+                          content-type: "{{attachment_content_type}}"
+                          hide-thumbnail: false
                         push:
                           sound:
-                            name: "{{sound}}"
-                            volume: "{{ iif(sound == 'none', 0, volume) }}"
-                          interruption-level: "{{ iif(critical, 1, interruption_level) }}"
+                            name: none
+                            volume: 0
+                          interruption-level: passive
                         entity_id: "{{ios_live_view}}"
-                        # Actions
                         actions:
-                          - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                          - action: URI
                             title: "{{button_1}}"
                             uri: "{{url_1}}"
-                            icon: "{{icon_1}}"
-                            destructive: "{{not '/' in url_1}}"
-                          - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                          - action: URI
                             title: "{{button_2}}"
                             uri: "{{url_2}}"
-                            icon: "{{icon_2}}"
-                            destructive: "{{not '/' in url_2}}"
-                          - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
-                            title: "{{button_3}}"
-                            uri: "{{url_3}}"
-                            icon: "{{icon_3}}"
-                            destructive: "{{not '/' in url_3}}"
+                          - action: "{{url_3}}"
+                            title: "Silence {{ silence_minutes }}m"
+            default:
+              - action: "notify.{{ notify_group_target }}"
+                data:
+                  title: "{{title}}"
+                  message: "{{message}}"
+                  data:
+                    tag: "{{ tag }}"
+                    group: "{{ group }}"
+                    color: "{{color}}"
+                    subject: "{{subtitle}}"
+                    image: "{{attachment}}"
+                    clickAction: "{{tap_action}}"
+                    ttl: 0
+                    priority: high
+                    alert_once: true
+                    notification_icon: "{{icon}}"
+                    sticky: "{{sticky}}"
+                    channel: "{{channel}}"
+                    car_ui: "{{android_auto}}"
+                    subtitle: "{{subtitle}}"
+                    fontsize: "{{tv_size}}"
+                    position: "{{tv_position}}"
+                    duration: "{{tv_duration}}"
+                    transparency: "{{tv_transparency}}"
+                    interrupt: "{{tv_interrupt}}"
+                    url: "{{tap_action}}"
+                    attachment:
+                      url: "{{attachment}}"
+                      content-type: "{{attachment_content_type}}"
+                      hide-thumbnail: false
+                    push:
+                      sound:
+                        name: none
+                        volume: 0
+                      interruption-level: passive
+                    entity_id: "{{ios_live_view}}"
+                    actions:
+                      - action: URI
+                        title: "{{button_1}}"
+                        uri: "{{url_1}}"
+                      - action: URI
+                        title: "{{button_2}}"
+                        uri: "{{url_2}}"
+                      - action: "{{url_3}}"
+                        title: "Silence {{ silence_minutes }}m"
+      - alias: "Final GenAI Review Summary"
+        conditions:
+          - condition: trigger
+            id: genai-final
+          - "{{ genai_final }}"
+          - "{{ type == 'genai' }}"
+          - "{{ input_camera_name|select('equalto', camera)|list|length>0 }}"
+        sequence:
+          - variables:
+              event: "{{ trigger.payload_json }}"
+              detections: "{{ event['after']['data']['detections'] | default([]) }}"
+              review_id: "{{ event['after']['id'] }}"
+              id: "{{ detections[0] if detections | count > 0 else event['after']['id'] }}"
+              objects: "{{ event['after']['data']['objects'] | default([]) }}"
+              label: "{{ (objects | first | default('GenAI')) | replace('_', ' ') | title }}"
+              severity: "{{ event['after']['severity'] }}"
+              after_zones: "{{ event['after']['data']['zones'] | default([]) | list | lower }}"
+              any_zones_entered: "{{ zones | length == 0 or ((zones | select('in', after_zones) | list | length) > 0) }}"
+              zone_single_satisfied: "{{ any_zones_entered if zone_only else true }}"
+              all_zones_entered: "{{ zones | length == 0 or ((zones | reject('in', after_zones) | list | length) == 0) }}"
+              zone_multi_satisfied: "{{ all_zones_entered if zone_only and zone_multi else true }}"
+              ordered_zones_match: >
+                {% set ns = namespace(intersection=[]) %}
+                {% for item in after_zones %}
+                    {% if item in zones %}
+                        {% set ns.intersection = ns.intersection + [item] %}
+                    {% endif %}
+                {% endfor %}
+                {{ ns.intersection == zones }}
+              zone_order_satisfied: "{{ (zone_only and zone_multi and ordered_zones_match) if zone_order_enforced else true }}"
+              zones_satisfied: "{{ zone_single_satisfied and zone_multi_satisfied and zone_order_satisfied }}"
+              severity_satisfied: "{{ ((input_severity | select('equalto', severity) | list | length) > 0) }}"
+              objects_satisfied: "{{ not labels|length or labels|select('in', objects)|list|length > 0 or ('person-verified' in objects and 'person' in labels) }}"
+              home: "{{ presence_entity != '' and presence_entity|expand|selectattr('state','eq','home')|list|length != 0 }}"
+              state_satisfied: "{{ not state_only or states(input_entity)|lower in states_filter }}"
+              custom_filter: !input custom_filter
+              metadata: "{{ event['after']['data']['metadata'] | default({}) }}"
+              genai_title: "{{ metadata.title | default('') }}"
+              genai_threat_level: "{{ metadata.get('potential_threat_level', 0) | int(0) }}"
+              title: >-
+                {% if genai_threat_level == 2 %}
+                  Security Concern: {{ genai_title }}
+                {% elif genai_threat_level == 1 %}
+                  Needs Review: {{ genai_title }}
+                {% else %}
+                  {{ genai_title }}
+                {% endif %}
+              message: "{{ metadata.scene | default('') if genai_final_description else '' }}"
+              subtitle: !input subtitle
+              icon: !input icon
+              group: !input group
+              tag: !input tag
+              channel: !input channel
+              color: !input color
+              sticky: !input sticky
+              attachment: !input genai_final_attachment
+              tap_action: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
+              button_1: View Clip
+              button_2: View Snapshot
+              url_1: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
+              url_2: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg"
+              url_3: "silence-{{ this.entity_id }}"
+              ios_live_view: !input ios_live_view
+              android_auto: !input android_auto
+              tv: !input tv
+              tv_position: !input tv_position
+              tv_size: !input tv_size
+              tv_duration: !input tv_duration
+              tv_transparency: !input tv_transparency
+              tv_interrupt: !input tv_interrupt
+              tv_image: >
+                {% if 'review_preview.gif' in attachment or 'event_preview.gif' in attachment %}
+                  {{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg
+                {% else %}
+                  {{attachment}}
+                {% endif %}
+              telegram_caption: "{{ title ~ ('\n' ~ message if message else '') }}"
+              attachment_content_type: "{{ 'jpeg' if 'jpg' in attachment else 'gif' }}"
+          - choose:
+              - conditions:
+                  - "{{ detections | count > 0 }}"
+                  - "{{ severity_satisfied }}"
+                  - "{{ objects_satisfied }}"
+                  - "{{ zones_satisfied }}"
+                  - "{{ not home }}"
+                  - "{{ state_satisfied }}"
+                  - "{{ custom_filter }}"
+                sequence:
+                  - choose:
+                      - conditions: "{{ telegram }}"
+                        sequence:
+                          - choose:
+                              - conditions: "{{ 'gif' in attachment }}"
+                                sequence:
+                                  - service: "{{ telegram_animation_service }}"
+                                    data:
+                                      chat_id: "{{telegram_chat_id}}"
+                                      caption: "{{telegram_caption}}"
+                                      url: "{{attachment|replace(base_url, telegram_base_url)}}"
+                                      inline_keyboard:
+                                        - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
+                                        - [["Silence {{ silence_minutes }}m", "{{url_3}}"]]
+                            default:
+                              - service: "{{ telegram_photo_service }}"
+                                data:
+                                  chat_id: "{{telegram_chat_id}}"
+                                  caption: "{{telegram_caption}}"
+                                  url: "{{attachment|replace(base_url, telegram_base_url)}}"
+                                  inline_keyboard:
+                                    - [["{{button_1}}", "{{url_1}}"], ["{{button_2}}", "{{url_2}}"]]
+                                    - [["Silence {{ silence_minutes }}m", "{{url_3}}"]]
+                      - conditions: "{{ not notify_group_target }}"
+                        sequence:
+                          - device_id: !input notify_device
+                            domain: mobile_app
+                            type: notify
+                            title: "{{title}}"
+                            message: "{{message}}"
+                            data:
+                              tag: "{{ tag }}"
+                              group: "{{ group }}"
+                              color: "{{color}}"
+                              subject: "{{subtitle}}"
+                              image: "{{attachment}}"
+                              clickAction: "{{tap_action}}"
+                              ttl: 0
+                              priority: high
+                              alert_once: true
+                              notification_icon: "{{icon}}"
+                              sticky: "{{sticky}}"
+                              channel: "{{channel}}"
+                              car_ui: "{{android_auto}}"
+                              subtitle: "{{subtitle}}"
+                              url: "{{tap_action}}"
+                              attachment:
+                                url: "{{attachment}}"
+                                content-type: "{{attachment_content_type}}"
+                                hide-thumbnail: false
+                              push:
+                                sound:
+                                  name: none
+                                  volume: 0
+                                interruption-level: passive
+                              entity_id: "{{ios_live_view}}"
+                              actions:
+                                - action: URI
+                                  title: "{{button_1}}"
+                                  uri: "{{url_1}}"
+                                - action: URI
+                                  title: "{{button_2}}"
+                                  uri: "{{url_2}}"
+                                - action: "{{url_3}}"
+                                  title: "Silence {{ silence_minutes }}m"
+                      - conditions: "{{ tv }}"
+                        sequence:
+                          - action: "notify.{{ notify_group_target }}"
+                            data:
+                              title: "{{title}}"
+                              message: "{{message}}"
+                              data:
+                                tag: "{{ tag }}"
+                                group: "{{ group }}"
+                                color: "{{color}}"
+                                subject: "{{subtitle}}"
+                                clickAction: "{{tap_action}}"
+                                ttl: 0
+                                priority: high
+                                alert_once: true
+                                notification_icon: "{{icon}}"
+                                sticky: "{{sticky}}"
+                                channel: "{{channel}}"
+                                car_ui: "{{android_auto}}"
+                                image:
+                                  url: "{{tv_image}}"
+                                fontsize: "{{tv_size}}"
+                                position: "{{tv_position}}"
+                                duration: "{{tv_duration}}"
+                                transparency: "{{tv_transparency}}"
+                                interrupt: "{{tv_interrupt}}"
+                                timeout: 30
+                                subtitle: "{{subtitle}}"
+                                url: "{{tap_action}}"
+                                attachment:
+                                  url: "{{attachment}}"
+                                  content-type: "{{attachment_content_type}}"
+                                  hide-thumbnail: false
+                                push:
+                                  sound:
+                                    name: none
+                                    volume: 0
+                                  interruption-level: passive
+                                entity_id: "{{ios_live_view}}"
+                                actions:
+                                  - action: URI
+                                    title: "{{button_1}}"
+                                    uri: "{{url_1}}"
+                                  - action: URI
+                                    title: "{{button_2}}"
+                                    uri: "{{url_2}}"
+                                  - action: "{{url_3}}"
+                                    title: "Silence {{ silence_minutes }}m"
+                    default:
+                      - action: "notify.{{ notify_group_target }}"
+                        data:
+                          title: "{{title}}"
+                          message: "{{message}}"
+                          data:
+                            tag: "{{ tag }}"
+                            group: "{{ group }}"
+                            color: "{{color}}"
+                            subject: "{{subtitle}}"
+                            image: "{{attachment}}"
+                            clickAction: "{{tap_action}}"
+                            ttl: 0
+                            priority: high
+                            alert_once: true
+                            notification_icon: "{{icon}}"
+                            sticky: "{{sticky}}"
+                            channel: "{{channel}}"
+                            car_ui: "{{android_auto}}"
+                            subtitle: "{{subtitle}}"
+                            fontsize: "{{tv_size}}"
+                            position: "{{tv_position}}"
+                            duration: "{{tv_duration}}"
+                            transparency: "{{tv_transparency}}"
+                            interrupt: "{{tv_interrupt}}"
+                            url: "{{tap_action}}"
+                            attachment:
+                              url: "{{attachment}}"
+                              content-type: "{{attachment_content_type}}"
+                              hide-thumbnail: false
+                            push:
+                              sound:
+                                name: none
+                                volume: 0
+                              interruption-level: passive
+                            entity_id: "{{ios_live_view}}"
+                            actions:
+                              - action: URI
+                                title: "{{button_1}}"
+                                uri: "{{url_1}}"
+                              - action: URI
+                                title: "{{button_2}}"
+                                uri: "{{url_2}}"
+                              - action: "{{url_3}}"
+                                title: "Silence {{ silence_minutes }}m"
       - alias: "Frigate Event"
         conditions:
           - condition: trigger
@@ -1525,7 +1908,7 @@ actions:
                       - choose:
                           - conditions: "{{ telegram }}"
                             sequence:
-                              - action: telegram_bot.send_photo
+                              - service: "{{ telegram_photo_service }}"
                                 data:
                                   chat_id: "{{telegram_chat_id}}"
                                   caption: "{{message}}"
@@ -1747,7 +2130,7 @@ actions:
                 - variables:
                     # use the subsequent attchment variable if set
                     attachment_2: !input attachment_2
-                    attachment: "{{iif(attachment_2, attachment_2, attachment)}}"
+                    attachment: "{{ attachment if attachment_2 in ['none', ''] else attachment_2 }}"
 
                     event: "{{ wait.trigger.payload_json }}"
                     type: "{{event['type']}}"
@@ -1979,7 +2362,7 @@ actions:
                                             - "{{ event['type'] == 'end' }}"
                                             - "{{ video | length > 0 }}"
                                           sequence:
-                                            - action: telegram_bot.send_video
+                                            - service: "{{ telegram_video_service }}"
                                               data:
                                                 chat_id: "{{telegram_chat_id}}"
                                                 caption: "{{message}}"
@@ -2002,7 +2385,7 @@ actions:
                                                       ],
                                                     ]
                                       default:
-                                        - action: telegram_bot.send_photo
+                                        - service: "{{ telegram_photo_service }}"
                                           data:
                                             chat_id: "{{telegram_chat_id}}"
                                             caption: "{{message}}"

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -1,5 +1,5 @@
 blueprint:
-  name: Frigate Notifications (0.14.0.4m-genai-custom)
+  name: Frigate Notifications (0.15.0.1)
   author: SgtBatten
   homeassistant:
     min_version: 2024.11.0
@@ -49,7 +49,7 @@ blueprint:
           multiple: true
     notify_device:
       name: Mobile Device
-      description: Select a device that runs the official Home Assistant app to receive notifications. If you wish to notify a group of devices and/or Android/Fire TV use the field below to override this selection. This will be ignored in that case but is still required.
+      description: Select a device that runs the official Home Assistant app to receive notifications. When this is the only notification target, Frigate clip links are automatically adjusted for that device platform (Android uses clip.mp4, iOS uses master.m3u8). If you wish to notify a group of devices and/or Android/Fire TV use the field below to override this selection. This will be ignored in that case but is still required.
       default: false
       selector:
         device:
@@ -61,6 +61,8 @@ blueprint:
         Send notifications via notify.notify instead of a single mobile device.
 
         If enabled, this overrides the Mobile Device option, but Notification Group / Android/Fire TV below will still take priority when set.
+
+        Important: when using Notify All Devices or a notification group that includes iOS devices, set Tap Action URL and any clip action button URLs to View Clip (iOS). The blueprint can only auto-select the correct Frigate clip URL when sending to one selected mobile app device.
       default: false
       selector:
         boolean:
@@ -324,10 +326,10 @@ blueprint:
                 - label: Object 1 Event GIF
                   value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/event_preview.gif?format=ts"
                 - label: Clip mp4
-                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
-                - label: Clip m3u8 (IOS)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/clip.mp4"
+                - label: Clip m3u8 (iOS)
                   # requires frigate integration 5.7.0+
-                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/master.m3u8"
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/master.m3u8"
               mode: dropdown
         final_update:
           name: Final update (Optional)
@@ -412,6 +414,8 @@ blueprint:
               options:
                 - "{{camera}}-frigate-notification"
                 - "{{camera}}-frigate-doorbell-notification"
+                - "frigate-notification"
+              custom_value: true
         tag:
           name: Tag
           description: The Tag is used to identify individual notifications in order to replace them with updated images/text. Default is the Event ID 
@@ -815,21 +819,23 @@ blueprint:
           description:
             The URL to open when tapping on the notification. Some presets are provided, you can also set your own by typing in the box.
 
+            When sending to one selected mobile app device, Frigate clip links are auto-adjusted for Android or iOS. When using Notify All Devices or a notification group that includes iOS devices, choose View Clip (iOS) for clip playback on iPhone/iPad.
+
             These options define the text and URLs associated with the three action buttons at the bottom of the notification.
-          default: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
+          default: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/clip.mp4"
           selector:
             select:
               options:
                 - label: View Clip
-                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
-                - label: View Clip (IOS)
-                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/master.m3u8"
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/clip.mp4"
+                - label: View Clip (iOS)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/master.m3u8"
                 - label: View GIF
                   value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{review_id}}/review_preview.gif"
                 - label: View Snapshot
                   value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg"
                 - label: View Stream
-                  value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera'] | lower | replace('-','_')}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
+                  value: "{{base_url}}/api/camera_proxy_stream/camera.{{ camera | default('') | lower | replace('-','_') }}?token={{ state_attr('camera.' ~ (camera | default('')), 'access_token') }}"
                 - label: Open Home Assistant (web)
                   value: "{{base_url}}/lovelace"
                 - label: Open Home Assistant (app)
@@ -857,23 +863,23 @@ blueprint:
           default: "View Clip"
         url_1:
           name: Action Button 1 URL
-          description: Customise what happens when you press the first Action Button. Select from one of the preconfigured options or enter your own custom URL.
-          default: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
+          description: Customise what happens when you press the first Action Button. Select from one of the preconfigured options or enter your own custom URL. When sending to one selected mobile app device, Frigate clip links are auto-adjusted for Android or iOS. When using Notify All Devices or a notification group that includes iOS devices, choose View Clip (iOS) for clip playback on iPhone/iPad.
+          default: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/clip.mp4"
           selector:
             select:
               options:
                 - label: Silence New Notifications
-                  value: silence-{{ this.entity_id }}
+                  value: silence-{{ this.entity_id if this is defined and this.entity_id is defined else '' }}
                 - label: View Clip
-                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
-                - label: View Clip (IOS)
-                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/master.m3u8"
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/clip.mp4"
+                - label: View Clip (iOS)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/master.m3u8"
                 - label: View GIF
                   value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{review_id}}/review_preview.gif"
                 - label: View Snapshot
                   value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg"
                 - label: View Stream
-                  value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera'] | lower | replace('-','_')}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
+                  value: "{{base_url}}/api/camera_proxy_stream/camera.{{ camera | default('') | lower | replace('-','_') }}?token={{ state_attr('camera.' ~ (camera | default('')), 'access_token') }}"
                 - label: Open Home Assistant (web)
                   value: "{{base_url}}/lovelace"
                 - label: Open Home Assistant (app)
@@ -891,7 +897,7 @@ blueprint:
                 - label: Open Reolink App (Android)
                   value: app://com.mcu.reolink
                 - label: Custom Action (Manual Trigger)
-                  value: custom-{{ this.entity_id }}
+                  value: custom-{{ this.entity_id if this is defined and this.entity_id is defined else '' }}
               custom_value: true
         icon_1:
           name: Action Button 1 icon - iOS Only
@@ -909,15 +915,15 @@ blueprint:
             select:
               options:
                 - label: Silence New Notifications
-                  value: silence-{{ this.entity_id }}
+                  value: silence-{{ this.entity_id if this is defined and this.entity_id is defined else '' }}
                 - label: View Clip
-                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
-                - label: View Clip (IOS)
-                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/master.m3u8"
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/clip.mp4"
+                - label: View Clip (iOS)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/master.m3u8"
                 - label: View Snapshot
                   value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg"
                 - label: View Stream
-                  value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera'] | lower | replace('-','_')}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
+                  value: "{{base_url}}/api/camera_proxy_stream/camera.{{ camera | default('') | lower | replace('-','_') }}?token={{ state_attr('camera.' ~ (camera | default('')), 'access_token') }}"
                 - label: Open Home Assistant (web)
                   value: "{{base_url}}/lovelace"
                 - label: Open Home Assistant (app)
@@ -935,7 +941,7 @@ blueprint:
                 - label: Open Reolink App (Android)
                   value: app://com.mcu.reolink
                 - label: Custom Action (Manual Trigger)
-                  value: custom-{{ this.entity_id }}
+                  value: custom-{{ this.entity_id if this is defined and this.entity_id is defined else '' }}
               custom_value: true
         icon_2:
           name: Action Button 2 icon - iOS Only
@@ -948,20 +954,20 @@ blueprint:
         url_3:
           name: Action Button 3 URL
           description: Customise what happens when you press the third Action Button. Select from one of the preconfigured options or enter your own custom URL.
-          default: silence-{{ this.entity_id }}
+          default: silence-{{ this.entity_id if this is defined and this.entity_id is defined else '' }}
           selector:
             select:
               options:
                 - label: Silence New Notifications
-                  value: silence-{{ this.entity_id }}
+                  value: silence-{{ this.entity_id if this is defined and this.entity_id is defined else '' }}
                 - label: View Clip
-                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/clip.mp4"
-                - label: View Clip (IOS)
-                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/{{camera}}/master.m3u8"
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/clip.mp4"
+                - label: View Clip (iOS)
+                  value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/master.m3u8"
                 - label: View Snapshot
                   value: "{{base_url}}/api/frigate{{client_id}}/notifications/{{id}}/snapshot.jpg"
                 - label: View Stream
-                  value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera'] | lower | replace('-','_')}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
+                  value: "{{base_url}}/api/camera_proxy_stream/camera.{{ camera | default('') | lower | replace('-','_') }}?token={{ state_attr('camera.' ~ (camera | default('')), 'access_token') }}"
                 - label: Open Home Assistant (web)
                   value: "{{base_url}}/lovelace"
                 - label: Open Home Assistant (app)
@@ -979,7 +985,7 @@ blueprint:
                 - label: Open Reolink App (Android)
                   value: app://com.mcu.reolink
                 - label: Custom Action (Manual Trigger)
-                  value: custom-{{ this.entity_id }}
+                  value: custom-{{ this.entity_id if this is defined and this.entity_id is defined else '' }}
               custom_value: true
         icon_3:
           name: Action Button 3 icon - iOS Only
@@ -1114,35 +1120,61 @@ triggers:
   - trigger: event
     event_type: mobile_app_notification_action
     event_data:
-      action: "silence-{{ this.entity_id }}"
+      action: "silence-{{ this.entity_id if this is defined and this.entity_id is defined else '' }}"
     id: silence
   - trigger: event
     event_type: telegram_callback
     event_data:
-      data: "silence-{{ this.entity_id }}"
+      data: "silence-{{ this.entity_id if this is defined and this.entity_id is defined else '' }}"
     id: silence
   - trigger: event
     event_type: mobile_app_notification_action
     event_data:
-      action: "custom-{{ this.entity_id}}"
+      action: 'custom-{{ this.entity_id if this is defined and this.entity_id is defined else "" }}'
     id: custom
   - trigger: event
     event_type: telegram_callback
     event_data:
-      action: "custom-{{ this.entity_id}}"
+      action: 'custom-{{ this.entity_id if this is defined and this.entity_id is defined else "" }}'
     id: custom
 variables:
   input_camera: !input camera
   input_camera_name: "{{input_camera|expand|map(attribute='attributes.camera_name', default='none')|list}}"
+  trigger_payload: "{{ trigger.payload_json if trigger is defined and trigger.payload_json is defined else dict() }}"
+  event: "{{ trigger_payload }}"
+  trigger_after: "{{ trigger_payload.get('after', dict()) if trigger_payload is mapping else dict() }}"
+  trigger_detections: "{{ trigger_after.get('data', {}).get('detections', []) if trigger_after is mapping else [] }}"
   camera: >
     {% if trigger.id == 'frigate-event' %}
-      {{ trigger.payload_json['after']['camera'] }}
+      {{ trigger_after.get('camera', '') }}
     {% elif trigger.id == 'genai-sprinter' %}
-      {{ trigger.payload_json['camera'] }}
+      {{ trigger_payload.get('camera', '') }}
     {% elif trigger.id == 'genai-final' %}
-      {{ trigger.payload_json['after']['camera'] }}
+      {{ trigger_after.get('camera', '') }}
+    {% else %}
+      {{ '' }}
     {% endif %}
   camera_name: "{{ camera | replace('_', ' ') | title }}"
+  review_id: >
+    {% if trigger.id == 'frigate-event' %}
+      {{ trigger_after.get('id', '') }}
+    {% elif trigger.id == 'genai-sprinter' %}
+      {{ trigger_payload.get('review_id', trigger_payload.get('id', '')) }}
+    {% elif trigger.id == 'genai-final' %}
+      {{ trigger_after.get('id', '') }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  id: >
+    {% if trigger.id == 'frigate-event' %}
+      {{ trigger_detections[0] if trigger_detections | count > 0 else trigger_after.get('id', '') }}
+    {% elif trigger.id == 'genai-sprinter' %}
+      {{ trigger_payload.get('id', '') }}
+    {% elif trigger.id == 'genai-final' %}
+      {{ trigger_detections[0] if trigger_detections | count > 0 else trigger_after.get('id', '') }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
   input_severity: !input review_severity
   severity: "{{trigger.payload_json['after']['severity'] if trigger.id == 'frigate-event'}}"
   type: "{{trigger.payload_json['type'] if trigger.id in ['frigate-event', 'genai-sprinter', 'genai-final']}}"
@@ -1162,6 +1194,7 @@ variables:
   genai_final_description: !input genai_final_description
   genai_final_attachment: !input genai_final_attachment
   ios_live_view: !input ios_live_view
+  ios_live_view_entity: "{{ ios_live_view if ios_live_view | string | length > 0 and states(ios_live_view) not in ['unknown', 'unavailable'] else '' }}"
   android_auto: !input android_auto
   notify_all_devices: !input notify_all_devices
   notify_group: !input notify_group
@@ -1171,6 +1204,19 @@ variables:
     {% else %}
       {{ notify_group | lower | regex_replace('^notify\.', '') | replace(' ','_') }}
     {% endif %}
+  selected_notify_device: !input notify_device
+  notify_device_manufacturer: "{{ device_attr(selected_notify_device, 'manufacturer') if selected_notify_device else '' }}"
+  notify_device_model: "{{ device_attr(selected_notify_device, 'model') if selected_notify_device else '' }}"
+  notify_device_name: "{{ device_attr(selected_notify_device, 'name') if selected_notify_device else '' }}"
+  notify_device_is_ios: >-
+    {{
+      (notify_device_manufacturer | lower == 'apple')
+      or ('iphone' in (notify_device_model | lower))
+      or ('ipad' in (notify_device_model | lower))
+      or ('iphone' in (notify_device_name | lower))
+      or ('ipad' in (notify_device_name | lower))
+      or ('ios' in (notify_device_model | lower))
+    }}
   telegram_chat_id: !input notify_telegram_chat_id
   telegram: "{{true if (telegram_chat_id | length > 0) else false}}"
   telegram_photo_service: "{{ 'telegram_bot' ~ '.send_photo' }}"
@@ -1318,12 +1364,32 @@ actions:
               sticky: !input sticky
               attachment: !input genai_sprinter_attachment
               tap_action: !input tap_action
+              tap_action_normalized: >-
+                {{ tap_action | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              tap_action_android: "{{ tap_action_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              tap_action_ios: "{{ tap_action_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              tap_action_single: "{{ tap_action_ios if notify_device_is_ios | bool else tap_action_android }}"
               button_1: !input button_1
               button_2: !input button_2
               button_3: !input button_3
               url_1: !input url_1
+              url_1_normalized: >-
+                {{ url_1 | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              url_1_android: "{{ url_1_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              url_1_ios: "{{ url_1_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              url_1_single: "{{ url_1_ios if notify_device_is_ios | bool else url_1_android }}"
               url_2: !input url_2
+              url_2_normalized: >-
+                {{ url_2 | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              url_2_android: "{{ url_2_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              url_2_ios: "{{ url_2_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              url_2_single: "{{ url_2_ios if notify_device_is_ios | bool else url_2_android }}"
               url_3: !input url_3
+              url_3_normalized: >-
+                {{ url_3 | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              url_3_android: "{{ url_3_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              url_3_ios: "{{ url_3_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              url_3_single: "{{ url_3_ios if notify_device_is_ios | bool else url_3_android }}"
               icon_1: !input icon_1
               icon_2: !input icon_2
               icon_3: !input icon_3
@@ -1332,6 +1398,7 @@ actions:
               interruption_level_updates: !input interruption_level_updates
               sound: !input sound
               ios_live_view: !input ios_live_view
+              ios_live_view_entity: "{{ ios_live_view if ios_live_view | string | length > 0 and states(ios_live_view) not in ['unknown', 'unavailable'] else '' }}"
               android_auto: !input android_auto
               tv: !input tv
               tv_position: !input tv_position
@@ -1383,7 +1450,7 @@ actions:
                       color: "{{color}}"
                       subject: "{{subtitle}}"
                       image: "{{attachment}}"
-                      clickAction: "{{tap_action}}"
+                      clickAction: "{{tap_action_android}}"
                       ttl: 0
                       priority: high
                       alert_once: "{{ alert_once }}"
@@ -1392,7 +1459,7 @@ actions:
                       channel: "{{'alarm_stream' if critical else channel}}"
                       car_ui: "{{android_auto}}"
                       subtitle: "{{subtitle}}"
-                      url: "{{tap_action}}"
+                      url: "{{tap_action_single}}"
                       attachment:
                         url: "{{attachment}}"
                         content-type: "{{attachment_content_type}}"
@@ -1402,23 +1469,23 @@ actions:
                           name: none
                           volume: 0
                         interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
-                      entity_id: "{{ios_live_view}}"
+                      entity_id: "{{ios_live_view_entity}}"
                       actions:
-                        - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                        - action: "{{ 'URI' if '/' in url_1_single else url_1_single }}"
                           title: "{{button_1}}"
-                          uri: "{{url_1}}"
+                          uri: "{{url_1_single}}"
                           icon: "{{icon_1}}"
-                          destructive: "{{not '/' in url_1}}"
-                        - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                          destructive: "{{not '/' in url_1_single}}"
+                        - action: "{{ 'URI' if '/' in url_2_single else url_2_single }}"
                           title: "{{button_2}}"
-                          uri: "{{url_2}}"
+                          uri: "{{url_2_single}}"
                           icon: "{{icon_2}}"
-                          destructive: "{{not '/' in url_2}}"
-                        - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                          destructive: "{{not '/' in url_2_single}}"
+                        - action: "{{ 'URI' if '/' in url_3_single else url_3_single }}"
                           title: "{{button_3}}"
-                          uri: "{{url_3}}"
+                          uri: "{{url_3_single}}"
                           icon: "{{icon_3}}"
-                          destructive: "{{not '/' in url_3}}"
+                          destructive: "{{not '/' in url_3_single}}"
               - conditions: "{{ tv }}"
                 sequence:
                   - action: "notify.{{ notify_group_target }}"
@@ -1430,7 +1497,7 @@ actions:
                         group: "{{ group }}"
                         color: "{{color}}"
                         subject: "{{subtitle}}"
-                        clickAction: "{{tap_action}}"
+                        clickAction: "{{tap_action_android}}"
                         ttl: 0
                         priority: high
                         alert_once: "{{ alert_once }}"
@@ -1447,7 +1514,7 @@ actions:
                         interrupt: "{{tv_interrupt}}"
                         timeout: 30
                         subtitle: "{{subtitle}}"
-                        url: "{{tap_action}}"
+                        url: "{{tap_action_ios}}"
                         attachment:
                           url: "{{attachment}}"
                           content-type: "{{attachment_content_type}}"
@@ -1457,23 +1524,23 @@ actions:
                             name: none
                             volume: 0
                           interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
-                        entity_id: "{{ios_live_view}}"
+                        entity_id: "{{ios_live_view_entity}}"
                         actions:
-                          - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                          - action: "{{ 'URI' if '/' in url_1_normalized else url_1 }}"
                             title: "{{button_1}}"
-                            uri: "{{url_1}}"
+                            uri: "{{url_1_normalized}}"
                             icon: "{{icon_1}}"
-                            destructive: "{{not '/' in url_1}}"
-                          - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                            destructive: "{{not '/' in url_1_normalized}}"
+                          - action: "{{ 'URI' if '/' in url_2_normalized else url_2 }}"
                             title: "{{button_2}}"
-                            uri: "{{url_2}}"
+                            uri: "{{url_2_normalized}}"
                             icon: "{{icon_2}}"
-                            destructive: "{{not '/' in url_2}}"
-                          - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                            destructive: "{{not '/' in url_2_normalized}}"
+                          - action: "{{ 'URI' if '/' in url_3_normalized else url_3 }}"
                             title: "{{button_3}}"
-                            uri: "{{url_3}}"
+                            uri: "{{url_3_normalized}}"
                             icon: "{{icon_3}}"
-                            destructive: "{{not '/' in url_3}}"
+                            destructive: "{{not '/' in url_3_normalized}}"
             default:
               - action: "notify.{{ notify_group_target }}"
                 data:
@@ -1485,7 +1552,7 @@ actions:
                     color: "{{color}}"
                     subject: "{{subtitle}}"
                     image: "{{attachment}}"
-                    clickAction: "{{tap_action}}"
+                    clickAction: "{{tap_action_android}}"
                     ttl: 0
                     priority: high
                     alert_once: "{{ alert_once }}"
@@ -1499,7 +1566,7 @@ actions:
                     duration: "{{tv_duration}}"
                     transparency: "{{tv_transparency}}"
                     interrupt: "{{tv_interrupt}}"
-                    url: "{{tap_action}}"
+                    url: "{{tap_action_ios}}"
                     attachment:
                       url: "{{attachment}}"
                       content-type: "{{attachment_content_type}}"
@@ -1509,23 +1576,23 @@ actions:
                         name: none
                         volume: 0
                       interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
-                    entity_id: "{{ios_live_view}}"
+                    entity_id: "{{ios_live_view_entity}}"
                     actions:
-                      - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                      - action: "{{ 'URI' if '/' in url_1_normalized else url_1 }}"
                         title: "{{button_1}}"
-                        uri: "{{url_1}}"
+                        uri: "{{url_1_normalized}}"
                         icon: "{{icon_1}}"
-                        destructive: "{{not '/' in url_1}}"
-                      - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                        destructive: "{{not '/' in url_1_normalized}}"
+                      - action: "{{ 'URI' if '/' in url_2_normalized else url_2 }}"
                         title: "{{button_2}}"
-                        uri: "{{url_2}}"
+                        uri: "{{url_2_normalized}}"
                         icon: "{{icon_2}}"
-                        destructive: "{{not '/' in url_2}}"
-                      - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                        destructive: "{{not '/' in url_2_normalized}}"
+                      - action: "{{ 'URI' if '/' in url_3_normalized else url_3 }}"
                         title: "{{button_3}}"
-                        uri: "{{url_3}}"
+                        uri: "{{url_3_normalized}}"
                         icon: "{{icon_3}}"
-                        destructive: "{{not '/' in url_3}}"
+                        destructive: "{{not '/' in url_3_normalized}}"
       - alias: "Final GenAI Review Summary"
         conditions:
           - condition: trigger
@@ -1583,12 +1650,32 @@ actions:
               sticky: !input sticky
               attachment: !input genai_final_attachment
               tap_action: !input tap_action
+              tap_action_normalized: >-
+                {{ tap_action | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              tap_action_android: "{{ tap_action_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              tap_action_ios: "{{ tap_action_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              tap_action_single: "{{ tap_action_ios if notify_device_is_ios | bool else tap_action_android }}"
               button_1: !input button_1
               button_2: !input button_2
               button_3: !input button_3
               url_1: !input url_1
+              url_1_normalized: >-
+                {{ url_1 | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              url_1_android: "{{ url_1_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              url_1_ios: "{{ url_1_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              url_1_single: "{{ url_1_ios if notify_device_is_ios | bool else url_1_android }}"
               url_2: !input url_2
+              url_2_normalized: >-
+                {{ url_2 | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              url_2_android: "{{ url_2_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              url_2_ios: "{{ url_2_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              url_2_single: "{{ url_2_ios if notify_device_is_ios | bool else url_2_android }}"
               url_3: !input url_3
+              url_3_normalized: >-
+                {{ url_3 | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              url_3_android: "{{ url_3_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              url_3_ios: "{{ url_3_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              url_3_single: "{{ url_3_ios if notify_device_is_ios | bool else url_3_android }}"
               icon_1: !input icon_1
               icon_2: !input icon_2
               icon_3: !input icon_3
@@ -1597,6 +1684,7 @@ actions:
               interruption_level_updates: !input interruption_level_updates
               sound: !input sound
               ios_live_view: !input ios_live_view
+              ios_live_view_entity: "{{ ios_live_view if ios_live_view | string | length > 0 and states(ios_live_view) not in ['unknown', 'unavailable'] else '' }}"
               android_auto: !input android_auto
               tv: !input tv
               tv_position: !input tv_position
@@ -1658,7 +1746,7 @@ actions:
                               color: "{{color}}"
                               subject: "{{subtitle}}"
                               image: "{{attachment}}"
-                              clickAction: "{{tap_action}}"
+                              clickAction: "{{tap_action_android}}"
                               ttl: 0
                               priority: high
                               alert_once: "{{ alert_once }}"
@@ -1667,7 +1755,7 @@ actions:
                               channel: "{{'alarm_stream' if critical else channel}}"
                               car_ui: "{{android_auto}}"
                               subtitle: "{{subtitle}}"
-                              url: "{{tap_action}}"
+                              url: "{{tap_action_single}}"
                               attachment:
                                 url: "{{attachment}}"
                                 content-type: "{{attachment_content_type}}"
@@ -1677,23 +1765,23 @@ actions:
                                   name: none
                                   volume: 0
                                 interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
-                              entity_id: "{{ios_live_view}}"
+                              entity_id: "{{ios_live_view_entity}}"
                               actions:
-                                - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                                - action: "{{ 'URI' if '/' in url_1_single else url_1_single }}"
                                   title: "{{button_1}}"
-                                  uri: "{{url_1}}"
+                                  uri: "{{url_1_single}}"
                                   icon: "{{icon_1}}"
-                                  destructive: "{{not '/' in url_1}}"
-                                - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                                  destructive: "{{not '/' in url_1_single}}"
+                                - action: "{{ 'URI' if '/' in url_2_single else url_2_single }}"
                                   title: "{{button_2}}"
-                                  uri: "{{url_2}}"
+                                  uri: "{{url_2_single}}"
                                   icon: "{{icon_2}}"
-                                  destructive: "{{not '/' in url_2}}"
-                                - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                  destructive: "{{not '/' in url_2_single}}"
+                                - action: "{{ 'URI' if '/' in url_3_single else url_3_single }}"
                                   title: "{{button_3}}"
-                                  uri: "{{url_3}}"
+                                  uri: "{{url_3_single}}"
                                   icon: "{{icon_3}}"
-                                  destructive: "{{not '/' in url_3}}"
+                                  destructive: "{{not '/' in url_3_single}}"
                       - conditions: "{{ tv }}"
                         sequence:
                           - action: "notify.{{ notify_group_target }}"
@@ -1705,7 +1793,7 @@ actions:
                                 group: "{{ group }}"
                                 color: "{{color}}"
                                 subject: "{{subtitle}}"
-                                clickAction: "{{tap_action}}"
+                                clickAction: "{{tap_action_android}}"
                                 ttl: 0
                                 priority: high
                                 alert_once: "{{ alert_once }}"
@@ -1722,7 +1810,7 @@ actions:
                                 interrupt: "{{tv_interrupt}}"
                                 timeout: 30
                                 subtitle: "{{subtitle}}"
-                                url: "{{tap_action}}"
+                                url: "{{tap_action_ios}}"
                                 attachment:
                                   url: "{{attachment}}"
                                   content-type: "{{attachment_content_type}}"
@@ -1732,23 +1820,23 @@ actions:
                                     name: none
                                     volume: 0
                                   interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
-                                entity_id: "{{ios_live_view}}"
+                                entity_id: "{{ios_live_view_entity}}"
                                 actions:
-                                  - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                                  - action: "{{ 'URI' if '/' in url_1_normalized else url_1 }}"
                                     title: "{{button_1}}"
-                                    uri: "{{url_1}}"
+                                    uri: "{{url_1_normalized}}"
                                     icon: "{{icon_1}}"
-                                    destructive: "{{not '/' in url_1}}"
-                                  - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                                    destructive: "{{not '/' in url_1_normalized}}"
+                                  - action: "{{ 'URI' if '/' in url_2_normalized else url_2 }}"
                                     title: "{{button_2}}"
-                                    uri: "{{url_2}}"
+                                    uri: "{{url_2_normalized}}"
                                     icon: "{{icon_2}}"
-                                    destructive: "{{not '/' in url_2}}"
-                                  - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                    destructive: "{{not '/' in url_2_normalized}}"
+                                  - action: "{{ 'URI' if '/' in url_3_normalized else url_3 }}"
                                     title: "{{button_3}}"
-                                    uri: "{{url_3}}"
+                                    uri: "{{url_3_normalized}}"
                                     icon: "{{icon_3}}"
-                                    destructive: "{{not '/' in url_3}}"
+                                    destructive: "{{not '/' in url_3_normalized}}"
                     default:
                       - action: "notify.{{ notify_group_target }}"
                         data:
@@ -1760,7 +1848,7 @@ actions:
                             color: "{{color}}"
                             subject: "{{subtitle}}"
                             image: "{{attachment}}"
-                            clickAction: "{{tap_action}}"
+                            clickAction: "{{tap_action_android}}"
                             ttl: 0
                             priority: high
                             alert_once: "{{ alert_once }}"
@@ -1774,7 +1862,7 @@ actions:
                             duration: "{{tv_duration}}"
                             transparency: "{{tv_transparency}}"
                             interrupt: "{{tv_interrupt}}"
-                            url: "{{tap_action}}"
+                            url: "{{tap_action_ios}}"
                             attachment:
                               url: "{{attachment}}"
                               content-type: "{{attachment_content_type}}"
@@ -1784,23 +1872,23 @@ actions:
                                 name: none
                                 volume: 0
                               interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
-                            entity_id: "{{ios_live_view}}"
+                            entity_id: "{{ios_live_view_entity}}"
                             actions:
-                              - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                              - action: "{{ 'URI' if '/' in url_1_normalized else url_1 }}"
                                 title: "{{button_1}}"
-                                uri: "{{url_1}}"
+                                uri: "{{url_1_normalized}}"
                                 icon: "{{icon_1}}"
-                                destructive: "{{not '/' in url_1}}"
-                              - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                                destructive: "{{not '/' in url_1_normalized}}"
+                              - action: "{{ 'URI' if '/' in url_2_normalized else url_2 }}"
                                 title: "{{button_2}}"
-                                uri: "{{url_2}}"
+                                uri: "{{url_2_normalized}}"
                                 icon: "{{icon_2}}"
-                                destructive: "{{not '/' in url_2}}"
-                              - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                destructive: "{{not '/' in url_2_normalized}}"
+                              - action: "{{ 'URI' if '/' in url_3_normalized else url_3 }}"
                                 title: "{{button_3}}"
-                                uri: "{{url_3}}"
+                                uri: "{{url_3_normalized}}"
                                 icon: "{{icon_3}}"
-                                destructive: "{{not '/' in url_3}}"
+                                destructive: "{{not '/' in url_3_normalized}}"
       - alias: "Frigate Event"
         conditions:
           - condition: trigger
@@ -1868,12 +1956,32 @@ actions:
               message: !input message
               subtitle: !input subtitle
               tap_action: !input tap_action
+              tap_action_normalized: >-
+                {{ tap_action | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              tap_action_android: "{{ tap_action_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              tap_action_ios: "{{ tap_action_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              tap_action_single: "{{ tap_action_ios if notify_device_is_ios | bool else tap_action_android }}"
               button_1: !input button_1
               button_2: !input button_2
               button_3: !input button_3
               url_1: !input url_1
+              url_1_normalized: >-
+                {{ url_1 | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              url_1_android: "{{ url_1_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              url_1_ios: "{{ url_1_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              url_1_single: "{{ url_1_ios if notify_device_is_ios | bool else url_1_android }}"
               url_2: !input url_2
+              url_2_normalized: >-
+                {{ url_2 | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              url_2_android: "{{ url_2_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              url_2_ios: "{{ url_2_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              url_2_single: "{{ url_2_ios if notify_device_is_ios | bool else url_2_android }}"
               url_3: !input url_3
+              url_3_normalized: >-
+                {{ url_3 | regex_replace('(.*?/notifications/[^/]+)/[^/]+/(clip\.mp4|master\.m3u8)$', '\1/\2') }}
+              url_3_android: "{{ url_3_normalized | replace('/master.m3u8', '/clip.mp4') }}"
+              url_3_ios: "{{ url_3_normalized | replace('/clip.mp4', '/master.m3u8') }}"
+              url_3_single: "{{ url_3_ios if notify_device_is_ios | bool else url_3_android }}"
               icon_1: !input icon_1
               icon_2: !input icon_2
               icon_3: !input icon_3
@@ -2032,7 +2140,7 @@ actions:
                                   subject: "{{subtitle}}"
                                   image: "{{attachment}}"
                                   video: "{{video}}"
-                                  clickAction: "{{tap_action}}"
+                                  clickAction: "{{tap_action_android}}"
                                   ttl: 0
                                   priority: high
                                   notification_icon: "{{icon}}"
@@ -2041,7 +2149,7 @@ actions:
                                   car_ui: "{{android_auto}}"
                                   # iOS Specific
                                   subtitle: "{{subtitle}}"
-                                  url: "{{tap_action}}"
+                                  url: "{{tap_action_single}}"
                                   attachment:
                                     url: "{{video if video else attachment }}"
                                     content-type: "{{ 'application/vnd.apple.mpegurl' if 'm3u8' in video else 'mp4' if 'mp4' in video else 'jpeg' if 'jpg' in attachment else 'gif' }}"
@@ -2050,24 +2158,24 @@ actions:
                                       name: "{{sound}}"
                                       volume: "{{ iif(sound == 'none', 0, volume) }}"
                                     interruption-level: "{{ iif(critical, 1, interruption_level) }}"
-                                  entity_id: "{{ios_live_view}}"
+                                  entity_id: "{{ios_live_view_entity}}"
                                   # Actions
                                   actions:
-                                    - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                                    - action: "{{ 'URI' if '/' in url_1_single else url_1_single }}"
                                       title: "{{button_1}}"
-                                      uri: "{{url_1}}"
+                                      uri: "{{url_1_single}}"
                                       icon: "{{icon_1}}"
-                                      destructive: "{{not '/' in url_1}}"
-                                    - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                                      destructive: "{{not '/' in url_1_single}}"
+                                    - action: "{{ 'URI' if '/' in url_2_single else url_2_single }}"
                                       title: "{{button_2}}"
-                                      uri: "{{url_2}}"
+                                      uri: "{{url_2_single}}"
                                       icon: "{{icon_2}}"
-                                      destructive: "{{not '/' in url_2}}"
-                                    - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                      destructive: "{{not '/' in url_2_single}}"
+                                    - action: "{{ 'URI' if '/' in url_3_single else url_3_single }}"
                                       title: "{{button_3}}"
-                                      uri: "{{url_3}}"
+                                      uri: "{{url_3_single}}"
                                       icon: "{{icon_3}}"
-                                      destructive: "{{not '/' in url_3}}"
+                                      destructive: "{{not '/' in url_3_single}}"
                           - conditions: "{{ tv }}"
                             sequence:
                               - action: "notify.{{ notify_group_target }}"
@@ -2080,7 +2188,7 @@ actions:
                                     color: "{{color}}"
                                     # Android Specific
                                     subject: "{{subtitle}}"
-                                    clickAction: "{{tap_action}}"
+                                    clickAction: "{{tap_action_android}}"
                                     ttl: 0
                                     priority: high
                                     notification_icon: "{{icon}}"
@@ -2099,7 +2207,7 @@ actions:
                                     timeout: 30
                                     # iOS Specific
                                     subtitle: "{{subtitle}}"
-                                    url: "{{tap_action}}"
+                                    url: "{{tap_action_ios}}"
                                     attachment:
                                       url: "{{video if video else attachment }}"
                                       content-type: "{{ 'application/vnd.apple.mpegurl' if 'm3u8' in video else 'mp4' if 'mp4' in video else 'jpeg' if 'jpg' in attachment else 'gif' }}"
@@ -2108,24 +2216,24 @@ actions:
                                         name: "{{sound}}"
                                         volume: "{{ iif(sound == 'none', 0, volume) }}"
                                       interruption-level: "{{ iif(critical, 1, interruption_level) }}"
-                                    entity_id: "{{ios_live_view}}"
+                                    entity_id: "{{ios_live_view_entity}}"
                                     # Actions
                                     actions:
-                                      - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                                      - action: "{{ 'URI' if '/' in url_1_normalized else url_1 }}"
                                         title: "{{button_1}}"
-                                        uri: "{{url_1}}"
+                                        uri: "{{url_1_normalized}}"
                                         icon: "{{icon_1}}"
-                                        destructive: "{{not '/' in url_1}}"
-                                      - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                                        destructive: "{{not '/' in url_1_normalized}}"
+                                      - action: "{{ 'URI' if '/' in url_2_normalized else url_2 }}"
                                         title: "{{button_2}}"
-                                        uri: "{{url_2}}"
+                                        uri: "{{url_2_normalized}}"
                                         icon: "{{icon_2}}"
-                                        destructive: "{{not '/' in url_2}}"
-                                      - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                        destructive: "{{not '/' in url_2_normalized}}"
+                                      - action: "{{ 'URI' if '/' in url_3_normalized else url_3 }}"
                                         title: "{{button_3}}"
-                                        uri: "{{url_3}}"
+                                        uri: "{{url_3_normalized}}"
                                         icon: "{{icon_3}}"
-                                        destructive: "{{not '/' in url_3}}"
+                                        destructive: "{{not '/' in url_3_normalized}}"
                         default:
                           - action: "notify.{{ notify_group_target }}"
                             data:
@@ -2139,7 +2247,7 @@ actions:
                                 subject: "{{subtitle}}"
                                 image: "{{attachment}}"
                                 video: "{{video}}"
-                                clickAction: "{{tap_action}}"
+                                clickAction: "{{tap_action_android}}"
                                 ttl: 0
                                 priority: high
                                 notification_icon: "{{icon}}"
@@ -2154,7 +2262,7 @@ actions:
                                 transparency: "{{tv_transparency}}"
                                 interrupt: "{{tv_interrupt}}"
                                 # iOS Specific
-                                url: "{{tap_action}}"
+                                url: "{{tap_action_ios}}"
                                 attachment:
                                   url: "{{video if video else attachment }}"
                                   content-type: "{{ 'application/vnd.apple.mpegurl' if 'm3u8' in video else 'mp4' if 'mp4' in video else 'jpeg' if 'jpg' in attachment else 'gif' }}"
@@ -2163,24 +2271,24 @@ actions:
                                     name: "{{sound}}"
                                     volume: "{{ iif(sound == 'none', 0, volume) }}"
                                   interruption-level: "{{ iif(critical, 1, interruption_level) }}"
-                                entity_id: "{{ios_live_view}}"
+                                entity_id: "{{ios_live_view_entity}}"
                                 # Actions
                                 actions:
-                                  - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                                  - action: "{{ 'URI' if '/' in url_1_normalized else url_1 }}"
                                     title: "{{button_1}}"
-                                    uri: "{{url_1}}"
+                                    uri: "{{url_1_normalized}}"
                                     icon: "{{icon_1}}"
-                                    destructive: "{{not '/' in url_1}}"
-                                  - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                                    destructive: "{{not '/' in url_1_normalized}}"
+                                  - action: "{{ 'URI' if '/' in url_2_normalized else url_2 }}"
                                     title: "{{button_2}}"
-                                    uri: "{{url_2}}"
+                                    uri: "{{url_2_normalized}}"
                                     icon: "{{icon_2}}"
-                                    destructive: "{{not '/' in url_2}}"
-                                  - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                    destructive: "{{not '/' in url_2_normalized}}"
+                                  - action: "{{ 'URI' if '/' in url_3_normalized else url_3 }}"
                                     title: "{{button_3}}"
-                                    uri: "{{url_3}}"
+                                    uri: "{{url_3_normalized}}"
                                     icon: "{{icon_3}}"
-                                    destructive: "{{not '/' in url_3}}"
+                                    destructive: "{{not '/' in url_3_normalized}}"
                       - if: "{{tts and (not tts_helper or not alert_once or (tts_helper and id not in states(tts_helper)))}}"
                         then:
                           sequence:
@@ -2511,7 +2619,7 @@ actions:
                                         subject: "{{subtitle}}"
                                         image: "{{attachment}}"
                                         video: "{{video}}"
-                                        clickAction: "{{tap_action}}"
+                                        clickAction: "{{tap_action_android}}"
                                         ttl: 0
                                         priority: high
                                         alert_once: "{{ alert_once }}"
@@ -2521,7 +2629,7 @@ actions:
                                         car_ui: "{{android_auto}}"
                                         # iOS Specific
                                         subtitle: "{{subtitle}}"
-                                        url: "{{tap_action}}"
+                                        url: "{{tap_action_single}}"
                                         attachment:
                                           url: "{{video if video else attachment }}"
                                           content-type: "{{ 'application/vnd.apple.mpegurl' if 'm3u8' in video else 'mp4' if 'mp4' in video else 'jpeg' if 'jpg' in attachment else 'gif' }}"
@@ -2530,24 +2638,24 @@ actions:
                                             name: "{{ iif(silent_update, 'none', sound) }}"
                                             volume: "{{ iif((silent_update or sound == 'none'), 0, volume) }}"
                                           interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
-                                        entity_id: "{{ios_live_view}}"
+                                        entity_id: "{{ios_live_view_entity}}"
                                         # Actions
                                         actions:
-                                          - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                                          - action: "{{ 'URI' if '/' in url_1_single else url_1_single }}"
                                             title: "{{button_1}}"
-                                            uri: "{{url_1}}"
+                                            uri: "{{url_1_single}}"
                                             icon: "{{icon_1}}"
-                                            destructive: "{{not '/' in url_1}}"
-                                          - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                                            destructive: "{{not '/' in url_1_single}}"
+                                          - action: "{{ 'URI' if '/' in url_2_single else url_2_single }}"
                                             title: "{{button_2}}"
-                                            uri: "{{url_2}}"
+                                            uri: "{{url_2_single}}"
                                             icon: "{{icon_2}}"
-                                            destructive: "{{not '/' in url_2}}"
-                                          - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                            destructive: "{{not '/' in url_2_single}}"
+                                          - action: "{{ 'URI' if '/' in url_3_single else url_3_single }}"
                                             title: "{{button_3}}"
-                                            uri: "{{url_3}}"
+                                            uri: "{{url_3_single}}"
                                             icon: "{{icon_3}}"
-                                            destructive: "{{not '/' in url_3}}"
+                                            destructive: "{{not '/' in url_3_single}}"
                                 - conditions: "{{ tv }}"
                                   sequence:
                                     - action: "notify.{{ notify_group_target }}"
@@ -2560,7 +2668,7 @@ actions:
                                           color: "{{color}}"
                                           # Android Specific
                                           subject: "{{subtitle}}"
-                                          clickAction: "{{tap_action}}"
+                                          clickAction: "{{tap_action_android}}"
                                           ttl: 0
                                           priority: high
                                           alert_once: "{{ alert_once }}"
@@ -2580,7 +2688,7 @@ actions:
                                           timeout: 30
                                           # iOS Specific
                                           subtitle: "{{subtitle}}"
-                                          url: "{{tap_action}}"
+                                          url: "{{tap_action_ios}}"
                                           attachment:
                                             url: "{{video if video else attachment }}"
                                             content-type: "{{ 'application/vnd.apple.mpegurl' if 'm3u8' in video else 'mp4' if 'mp4' in video else 'jpeg' if 'jpg' in attachment else 'gif' }}"
@@ -2589,24 +2697,24 @@ actions:
                                               name: "{{ iif(silent_update, 'none', sound) }}"
                                               volume: "{{ iif((silent_update or sound == 'none'), 0, volume) }}"
                                             interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
-                                          entity_id: "{{ios_live_view}}"
+                                          entity_id: "{{ios_live_view_entity}}"
                                           # Actions
                                           actions:
-                                            - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                                            - action: "{{ 'URI' if '/' in url_1_normalized else url_1 }}"
                                               title: "{{button_1}}"
-                                              uri: "{{url_1}}"
+                                              uri: "{{url_1_normalized}}"
                                               icon: "{{icon_1}}"
-                                              destructive: "{{not '/' in url_1}}"
-                                            - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                                              destructive: "{{not '/' in url_1_normalized}}"
+                                            - action: "{{ 'URI' if '/' in url_2_normalized else url_2 }}"
                                               title: "{{button_2}}"
-                                              uri: "{{url_2}}"
+                                              uri: "{{url_2_normalized}}"
                                               icon: "{{icon_2}}"
-                                              destructive: "{{not '/' in url_2}}"
-                                            - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                              destructive: "{{not '/' in url_2_normalized}}"
+                                            - action: "{{ 'URI' if '/' in url_3_normalized else url_3 }}"
                                               title: "{{button_3}}"
-                                              uri: "{{url_3}}"
+                                              uri: "{{url_3_normalized}}"
                                               icon: "{{icon_3}}"
-                                              destructive: "{{not '/' in url_3}}"
+                                              destructive: "{{not '/' in url_3_normalized}}"
                               default:
                                 - action: "notify.{{ notify_group_target }}"
                                   data:
@@ -2620,7 +2728,7 @@ actions:
                                       subject: "{{subtitle}}"
                                       image: "{{attachment}}"
                                       video: "{{video}}"
-                                      clickAction: "{{tap_action}}"
+                                      clickAction: "{{tap_action_android}}"
                                       ttl: 0
                                       priority: high
                                       alert_once: "{{ alert_once }}"
@@ -2636,7 +2744,7 @@ actions:
                                       interrupt: "{{tv_interrupt}}"
                                       # iOS Specific
                                       subtitle: "{{subtitle}}"
-                                      url: "{{tap_action}}"
+                                      url: "{{tap_action_ios}}"
                                       attachment:
                                         url: "{{video if video else attachment }}"
                                         content-type: "{{ 'application/vnd.apple.mpegurl' if 'm3u8' in video else 'mp4' if 'mp4' in video else 'jpeg' if 'jpg' in attachment else 'gif' }}"
@@ -2645,24 +2753,24 @@ actions:
                                           name: "{{ iif(silent_update, 'none', sound) }}"
                                           volume: "{{ iif((silent_update or sound == 'none'), 0, volume) }}"
                                         interruption-level: "{{ iif(critical, 1, interruption_level_updates) }}"
-                                      entity_id: "{{ios_live_view}}"
+                                      entity_id: "{{ios_live_view_entity}}"
                                       # Actions
                                       actions:
-                                        - action: "{{ 'URI' if '/' in url_1 else url_1 }}"
+                                        - action: "{{ 'URI' if '/' in url_1_normalized else url_1 }}"
                                           title: "{{button_1}}"
-                                          uri: "{{url_1}}"
+                                          uri: "{{url_1_normalized}}"
                                           icon: "{{icon_1}}"
-                                          destructive: "{{not '/' in url_1}}"
-                                        - action: "{{ 'URI' if '/' in url_2 else url_2 }}"
+                                          destructive: "{{not '/' in url_1_normalized}}"
+                                        - action: "{{ 'URI' if '/' in url_2_normalized else url_2 }}"
                                           title: "{{button_2}}"
-                                          uri: "{{url_2}}"
+                                          uri: "{{url_2_normalized}}"
                                           icon: "{{icon_2}}"
-                                          destructive: "{{not '/' in url_2}}"
-                                        - action: "{{ 'URI' if '/' in url_3 else url_3 }}"
+                                          destructive: "{{not '/' in url_2_normalized}}"
+                                        - action: "{{ 'URI' if '/' in url_3_normalized else url_3 }}"
                                           title: "{{button_3}}"
-                                          uri: "{{url_3}}"
+                                          uri: "{{url_3_normalized}}"
                                           icon: "{{icon_3}}"
-                                          destructive: "{{not '/' in url_3}}"
+                                          destructive: "{{not '/' in url_3_normalized}}"
 
                             - if: "{{tts and (not tts_helper or not alert_once or (tts_helper and id not in states(tts_helper)))}}"
                               then:


### PR DESCRIPTION
Added a new GenAI section for full GenAI customization
- optional Sprinter GenAI toggle
- optional Final GenAI review-summary updates
- per-stage description toggles
- per-stage attachment selectors

Additionally added/fixed:
- all-devices notification support via `notify.notify`
- Telegram service compatibility hardening
- silent/passive GenAI update behavior