### PR TITLE
fix: restore correct icon on genai-event

### DIFF
--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -1345,18 +1345,12 @@ actions:
                   {% set data = namespace(labels=[]) %} 
                   {% if labels|length %}
                     {% for obj in objects|select('in', labels) %}
-                      {% if "-verified" in obj %}
-                      {% else %}
-                        {% set data.labels = data.labels + [obj] %}
-                      {% endif %}
+                        {% set data.labels = data.labels + [obj | regex_replace('-verified$', '')] %}
                     {% endfor %} {% set data.labels = data.labels + sub_labels %} 
                     {{ data.labels | unique | list | sort | join(", ") | title }}
                   {% else %}
                     {% for obj in objects %}
-                      {% if "-verified" in obj %}
-                      {% else %}
-                        {% set data.labels = data.labels + [obj] %}
-                      {% endif %}
+                        {% set data.labels = data.labels + [obj | regex_replace('-verified$', '')] %}
                     {% endfor %} {% set data.labels = data.labels + sub_labels %} 
                     {{ data.labels | unique | list | sort | join(", ") | title }}
                   {% endif %}
@@ -1822,18 +1816,12 @@ actions:
                         {% set data = namespace(labels=[]) %} 
                         {% if labels|length %}
                           {% for obj in objects|select('in', labels) %}
-                            {% if "-verified" in obj %}
-                            {% else %}
-                              {% set data.labels = data.labels + [obj] %}
-                            {% endif %}
+                              {% set data.labels = data.labels + [obj | regex_replace('-verified$', '')] %}
                           {% endfor %} {% set data.labels = data.labels + sub_labels %} 
                           {{ data.labels | unique | list | sort | join(", ") | title }}
                         {% else %}
                           {% for obj in objects %}
-                            {% if "-verified" in obj %}
-                            {% else %}
-                              {% set data.labels = data.labels + [obj] %}
-                            {% endif %}
+                              {% set data.labels = data.labels + [obj | regex_replace('-verified$', '')] %}
                           {% endfor %} {% set data.labels = data.labels + sub_labels %} 
                           {{ data.labels | unique | list | sort | join(", ") | title }}
                         {% endif %}

--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -1111,6 +1111,7 @@ actions:
               detections: "{{ event['after']['data']['detections'] }}"
               review_id: "{{ event['after']['id'] }}"
               id: "{{ detections[0] }}"
+              label: "{{ (objects | map('regex_replace', '-verified$', '') | first | default('')) | title }}"
               metadata: "{{ event['after']['data']['metadata'] | default({}) }}"
               genai_title: "{{ metadata.title | default('') }}"
               genai_shortSummary: "{{ metadata.shortSummary | default('') }}"
@@ -1125,6 +1126,7 @@ actions:
                 {% endif %}
               message: "{{ genai_shortSummary }}"
               subtitle: !input subtitle
+              icon: !input icon
               group: !input group
               tag: "{{ review_id }}"
               channel: !input channel
@@ -1172,6 +1174,7 @@ actions:
                         data:
                           tag: "{{ tag }}"
                           group: "{{ group }}"
+                          color: "{{color}}"
                           # Android Specific
                           subject: "{{subtitle}}"
                           image: "{{attachment}}"
@@ -1179,6 +1182,7 @@ actions:
                           clickAction: "{{tap_action}}"
                           ttl: 0
                           priority: high
+                          notification_icon: "{{icon}}"
                           sticky: "{{sticky}}"
                           channel: "{{'alarm_stream' if critical else channel}}"
                           car_ui: "{{android_auto}}"
@@ -1220,11 +1224,13 @@ actions:
                           data:
                             tag: "{{ tag }}"
                             group: "{{ group }}"
+                            color: "{{color}}"
                             # Android Specific
                             subject: "{{subtitle}}"
                             clickAction: "{{tap_action}}"
                             ttl: 0
                             priority: high
+                            notification_icon: "{{icon}}"
                             sticky: "{{sticky}}"
                             channel: "{{'alarm_stream' if critical else channel}}"
                             car_ui: "{{android_auto}}"
@@ -1275,6 +1281,7 @@ actions:
                       data:
                         tag: "{{ tag }}"
                         group: "{{ group }}"
+                        color: "{{color}}"
                         # Android Specific
                         subject: "{{subtitle}}"
                         image: "{{attachment}}"
@@ -1282,6 +1289,7 @@ actions:
                         clickAction: "{{tap_action}}"
                         ttl: 0
                         priority: high
+                        notification_icon: "{{icon}}"
                         sticky: "{{sticky}}"
                         channel: "{{'alarm_stream' if critical else channel}}"
                         car_ui: "{{android_auto}}"

--- a/Frigate_Camera_Notifications/Stable.yaml
+++ b/Frigate_Camera_Notifications/Stable.yaml
@@ -1071,6 +1071,7 @@ actions:
               detections: "{{ event['after']['data']['detections'] }}"
               review_id: "{{ event['after']['id'] }}"
               id: "{{ detections[0] }}"
+              label: "{{ (objects | map('regex_replace', '-verified$', '') | first | default('')) | title }}"
               metadata: "{{ event['after']['data']['metadata'] | default({}) }}"
               genai_title: "{{ metadata.title | default('') }}"
               genai_shortSummary: "{{ metadata.shortSummary | default('') }}"
@@ -1085,6 +1086,7 @@ actions:
                 {% endif %}
               message: "{{ genai_shortSummary }}"
               subtitle: !input subtitle
+              icon: !input icon
               group: !input group
               tag: "{{ review_id }}"
               channel: !input channel
@@ -1131,6 +1133,7 @@ actions:
                         data:
                           tag: "{{ tag }}"
                           group: "{{ group }}"
+                          color: "{{color}}"
                           # Android Specific
                           subject: "{{subtitle}}"
                           image: "{{attachment}}"
@@ -1138,6 +1141,7 @@ actions:
                           clickAction: "{{tap_action}}"
                           ttl: 0
                           priority: high
+                          notification_icon: "{{icon}}"
                           sticky: "{{sticky}}"
                           channel: "{{'alarm_stream' if critical else channel}}"
                           car_ui: "{{android_auto}}"
@@ -1177,11 +1181,13 @@ actions:
                           data:
                             tag: "{{ tag }}"
                             group: "{{ group }}"
+                            color: "{{color}}"
                             # Android Specific
                             subject: "{{subtitle}}"
                             clickAction: "{{tap_action}}"
                             ttl: 0
                             priority: high
+                            notification_icon: "{{icon}}"
                             sticky: "{{sticky}}"
                             channel: "{{'alarm_stream' if critical else channel}}"
                             car_ui: "{{android_auto}}"
@@ -1230,6 +1236,7 @@ actions:
                       data:
                         tag: "{{ tag }}"
                         group: "{{ group }}"
+                        color: "{{color}}"
                         # Android Specific
                         subject: "{{subtitle}}"
                         image: "{{attachment}}"
@@ -1237,6 +1244,7 @@ actions:
                         clickAction: "{{tap_action}}"
                         ttl: 0
                         priority: high
+                        notification_icon: "{{icon}}"
                         sticky: "{{sticky}}"
                         channel: "{{'alarm_stream' if critical else channel}}"
                         car_ui: "{{android_auto}}"

--- a/Frigate_Camera_Notifications/Stable.yaml
+++ b/Frigate_Camera_Notifications/Stable.yaml
@@ -1298,18 +1298,12 @@ actions:
                   {% set data = namespace(labels=[]) %} 
                   {% if labels|length %}
                     {% for obj in objects|select('in', labels) %}
-                      {% if "-verified" in obj %}
-                      {% else %}
-                        {% set data.labels = data.labels + [obj] %}
-                      {% endif %}
+                        {% set data.labels = data.labels + [obj | regex_replace('-verified$', '')] %}
                     {% endfor %} {% set data.labels = data.labels + sub_labels %} 
                     {{ data.labels | unique | list | sort | join(", ") | title }}
                   {% else %}
                     {% for obj in objects %}
-                      {% if "-verified" in obj %}
-                      {% else %}
-                        {% set data.labels = data.labels + [obj] %}
-                      {% endif %}
+                        {% set data.labels = data.labels + [obj | regex_replace('-verified$', '')] %}
                     {% endfor %} {% set data.labels = data.labels + sub_labels %} 
                     {{ data.labels | unique | list | sort | join(", ") | title }}
                   {% endif %}
@@ -1761,18 +1755,12 @@ actions:
                         {% set data = namespace(labels=[]) %} 
                         {% if labels|length %}
                           {% for obj in objects|select('in', labels) %}
-                            {% if "-verified" in obj %}
-                            {% else %}
-                              {% set data.labels = data.labels + [obj] %}
-                            {% endif %}
+                              {% set data.labels = data.labels + [obj | regex_replace('-verified$', '')] %}
                           {% endfor %} {% set data.labels = data.labels + sub_labels %} 
                           {{ data.labels | unique | list | sort | join(", ") | title }}
                         {% else %}
                           {% for obj in objects %}
-                            {% if "-verified" in obj %}
-                            {% else %}
-                              {% set data.labels = data.labels + [obj] %}
-                            {% endif %}
+                              {% set data.labels = data.labels + [obj | regex_replace('-verified$', '')] %}
                           {% endfor %} {% set data.labels = data.labels + sub_labels %} 
                           {{ data.labels | unique | list | sort | join(", ") | title }}
                         {% endif %}


### PR DESCRIPTION
- Add label variable to GenAI Summary derived from objects with -verified stripped, allowing icon template to evaluate correctly
- Set icon: '!input icon' so genai-event uses same icon as frigate-event