### PR TITLE
Change tag of genai-event from fixed {{ review_id }} to input tag

### DIFF
--- a/Frigate_Camera_Notifications/Beta.yaml
+++ b/Frigate_Camera_Notifications/Beta.yaml
@@ -1126,7 +1126,7 @@ actions:
               message: "{{ genai_shortSummary }}"
               subtitle: !input subtitle
               group: !input group
-              tag: "{{ review_id }}"
+              tag: !input tag
               channel: !input channel
               sticky: false
               sound: "none"


### PR DESCRIPTION
Currently, for genai trigger, the tagged is fixed to {{ review_id }} while for other review triggers, the tag is from automation input. This leads to duplicate notification for the same review #558. 